### PR TITLE
Fix #73 by extending list of NullUnmarked injections.

### DIFF
--- a/core/src/main/java/edu/ucr/cs/riple/core/Annotator.java
+++ b/core/src/main/java/edu/ucr/cs/riple/core/Annotator.java
@@ -267,7 +267,9 @@ public class Annotator {
                     // Just a sanity check.
                     return null;
                   }
-                  // For methods invoked in an initialization region, where the error is that `@Nullable` is being passed as an argument, we add a `@NullUnmarked` annotation to the called method.
+                  // For methods invoked in an initialization region, where the error is that
+                  // `@Nullable` is being passed as an argument, we add a `@NullUnmarked` annotation
+                  // to the called method.
                   if (error.messageType.equals("PASS_NULLABLE")) {
                     OnMethod calledMethod = error.nonnullTarget.toMethod();
                     return tree.findNode(calledMethod.method, calledMethod.clazz);

--- a/core/src/main/java/edu/ucr/cs/riple/core/Annotator.java
+++ b/core/src/main/java/edu/ucr/cs/riple/core/Annotator.java
@@ -267,8 +267,7 @@ public class Annotator {
                     // Just a sanity check.
                     return null;
                   }
-                  // method called in initialization region of class and received null for
-                  // arguments.
+                  // For methods invoked in an initialization region, where the error is that `@Nullable` is being passed as an argument, we add a `@NullUnmarked` annotation to the called method.
                   if (error.messageType.equals("PASS_NULLABLE")) {
                     OnMethod calledMethod = error.nonnullTarget.toMethod();
                     return tree.findNode(calledMethod.method, calledMethod.clazz);

--- a/core/src/main/java/edu/ucr/cs/riple/core/Annotator.java
+++ b/core/src/main/java/edu/ucr/cs/riple/core/Annotator.java
@@ -267,6 +267,8 @@ public class Annotator {
                     // Just a sanity check.
                     return null;
                   }
+                  // method called in initialization region of class and received null for
+                  // arguments.
                   if (error.messageType.equals("PASS_NULLABLE")) {
                     OnMethod calledMethod = error.nonnullTarget.toMethod();
                     return tree.findNode(calledMethod.method, calledMethod.clazz);
@@ -276,8 +278,6 @@ public class Annotator {
             .filter(Objects::nonNull)
             .map(node -> new AddMarkerAnnotation(node.location, config.nullUnMarkedAnnotation))
             .collect(Collectors.toSet());
-    // Collect methods received a nullable i their nonnull parameters where called in field
-    // declaration regions of classes (method == "null).
     injector.injectAnnotations(nullUnMarkedAnnotations);
 
     // Collect explicit Nullable initialization to fields

--- a/core/src/main/java/edu/ucr/cs/riple/core/Annotator.java
+++ b/core/src/main/java/edu/ucr/cs/riple/core/Annotator.java
@@ -313,7 +313,6 @@ public class Annotator {
             // Exclude already annotated fields with a general NullAway suppress warning.
             .filter(f -> !suppressWarningsAnnotations.contains(f))
             .collect(Collectors.toSet());
-
     injector.injectAnnotations(initializationSuppressWarningsAnnotations);
   }
 }

--- a/core/src/main/java/edu/ucr/cs/riple/core/Annotator.java
+++ b/core/src/main/java/edu/ucr/cs/riple/core/Annotator.java
@@ -48,6 +48,7 @@ import edu.ucr.cs.riple.injector.changes.AddAnnotation;
 import edu.ucr.cs.riple.injector.changes.AddMarkerAnnotation;
 import edu.ucr.cs.riple.injector.changes.AddSingleElementAnnotation;
 import edu.ucr.cs.riple.injector.location.OnField;
+import edu.ucr.cs.riple.injector.location.OnMethod;
 import edu.ucr.cs.riple.scanner.Serializer;
 import java.util.List;
 import java.util.Objects;
@@ -256,14 +257,27 @@ public class Annotator {
     // the method level.
     Set<AddAnnotation> nullUnMarkedAnnotations =
         remainingErrors.stream()
-            // filter non-method regions.
-            .filter(error -> !error.encMethod().equals("null"))
             // find the corresponding method nodes.
-            .map(error -> tree.findNode(error.encMethod(), error.encClass()))
-            // impossible, just sanity check or future nullness checker hints
+            .map(
+                error -> {
+                  if (!error.encMethod().equals("null")) {
+                    return tree.findNode(error.encMethod(), error.encClass());
+                  }
+                  if (error.nonnullTarget == null) {
+                    // Just a sanity check.
+                    return null;
+                  }
+                  if (error.messageType.equals("PASS_NULLABLE")) {
+                    OnMethod calledMethod = error.nonnullTarget.toMethod();
+                    return tree.findNode(calledMethod.method, calledMethod.clazz);
+                  }
+                  return null;
+                })
             .filter(Objects::nonNull)
             .map(node -> new AddMarkerAnnotation(node.location, config.nullUnMarkedAnnotation))
             .collect(Collectors.toSet());
+    // Collect methods received a nullable i their nonnull parameters where called in field
+    // declaration regions of classes (method == "null).
     injector.injectAnnotations(nullUnMarkedAnnotations);
 
     // Collect explicit Nullable initialization to fields
@@ -299,6 +313,7 @@ public class Annotator {
             // Exclude already annotated fields with a general NullAway suppress warning.
             .filter(f -> !suppressWarningsAnnotations.contains(f))
             .collect(Collectors.toSet());
+
     injector.injectAnnotations(initializationSuppressWarningsAnnotations);
   }
 }

--- a/core/src/test/java/edu/ucr/cs/riple/core/CoreTest.java
+++ b/core/src/test/java/edu/ucr/cs/riple/core/CoreTest.java
@@ -127,7 +127,7 @@ public class CoreTest extends BaseCoreTest {
   }
 
   @Test
-  public void field_assign_nullable_constructor() {
+  public void fieldAssignNullableConstructor() {
     coreTestHelper
         .addInputLines(
             "Main.java",
@@ -144,6 +144,28 @@ public class CoreTest extends BaseCoreTest {
         .toDepth(1)
         .addExpectedReports(
             new TReport(new OnParameter("Main.java", "test.Main", "Main(java.lang.Object)", 0), 1))
+        .start();
+  }
+
+  @Test
+  public void fieldAssignNullableConstructorForceResolveEnabled() {
+    coreTestHelper
+        .addInputLines(
+            "Main.java",
+            "package test;",
+            "public class Main {",
+            "   Object f;",
+            "   Main(Object f) {",
+            "     this.f = f;",
+            "   }",
+            "}",
+            "class C {",
+            "   Main main = new Main(null);",
+            "}")
+        .toDepth(1)
+        .addExpectedReports(
+            new TReport(new OnParameter("Main.java", "test.Main", "Main(java.lang.Object)", 0), 1))
+        .enableForceResolve()
         .start();
   }
 


### PR DESCRIPTION
This PR resolves #73 by adding `@NullUnmarked` annotations for called methods in field initializations that received a `@Nullable`. 


