### PR TITLE
WIP - Append first the injecting annotation

### DIFF
--- a/core/src/main/java/edu/ucr/cs/riple/core/log/Log.java
+++ b/core/src/main/java/edu/ucr/cs/riple/core/log/Log.java
@@ -31,30 +31,30 @@ public class Log {
    * Sum of number of nodes constructed in each {@link
    * edu.ucr.cs.riple.core.metadata.graph.ConflictGraph}.
    */
-  long node;
+  private long nodes;
   /** Number of build requests. */
-  long requested;
+  private long requested;
   /** Total time spent for annotator from start to finish. */
-  long time;
+  private long totalTime;
   /** Total time spent in building targets. */
-  long buildTime = 0;
+  private long buildTime = 0;
 
   /** Resets all log information. */
   public void reset() {
-    this.node = 0;
+    this.nodes = 0;
     this.requested = 0;
-    this.time = 0;
+    this.totalTime = 0;
     this.buildTime = 0;
   }
 
   @Override
   public String toString() {
     return "Total number of nodes="
-        + node
+        + nodes
         + "\nTotal number of Requested builds="
         + requested
         + "\nTotal time="
-        + time
+        + totalTime
         + "\nTotal time spent on builds="
         + buildTime;
   }
@@ -75,7 +75,7 @@ public class Log {
    * @param timer The return result of calling {@link Log#startTimer()}.
    */
   public void stopTimerAndCapture(long timer) {
-    this.time += System.currentTimeMillis() - timer;
+    this.totalTime += System.currentTimeMillis() - timer;
   }
 
   /**
@@ -94,12 +94,12 @@ public class Log {
   }
 
   /**
-   * Adds the passed parameter to the number of {@link Log#node}.
+   * Adds the passed parameter to the number of {@link Log#nodes}.
    *
-   * @param number Number of new nodes created in {@link
+   * @param numberOfNewNodesCreated Number of new nodes created in {@link
    *     edu.ucr.cs.riple.core.metadata.graph.ConflictGraph}.
    */
-  public void updateNodeNumber(long number) {
-    this.node += number;
+  public void updateNodeNumber(long numberOfNewNodesCreated) {
+    this.nodes += numberOfNewNodesCreated;
   }
 }

--- a/injector/src/main/java/edu/ucr/cs/riple/injector/changes/AddMarkerAnnotation.java
+++ b/injector/src/main/java/edu/ucr/cs/riple/injector/changes/AddMarkerAnnotation.java
@@ -42,15 +42,18 @@ public class AddMarkerAnnotation extends AddAnnotation {
   @Override
   public void visit(NodeWithAnnotations<?> node) {
     NodeList<AnnotationExpr> annotations = node.getAnnotations();
-    AnnotationExpr annotationExpr = new MarkerAnnotationExpr(annotationSimpleName);
 
     // Check if annot already exists.
     boolean annotAlreadyExists =
-        annotations.stream().anyMatch(annot -> annot.equals(annotationExpr));
+        annotations.stream()
+            .anyMatch(
+                annot ->
+                    annot.getName().toString().equals(annotationSimpleName)
+                        || annot.getName().toString().equals(annotation));
     if (annotAlreadyExists) {
       return;
     }
-    node.addMarkerAnnotation(annotationSimpleName);
+    annotations.addFirst(new MarkerAnnotationExpr(annotationSimpleName));
   }
 
   @Override

--- a/injector/src/main/java/edu/ucr/cs/riple/injector/changes/AddSingleElementAnnotation.java
+++ b/injector/src/main/java/edu/ucr/cs/riple/injector/changes/AddSingleElementAnnotation.java
@@ -144,6 +144,6 @@ public class AddSingleElementAnnotation extends AddAnnotation {
   private void addAnnotationExpressionOnNode(NodeWithAnnotations<?> node, Expression argument) {
     AnnotationExpr annotationExpr =
         new SingleMemberAnnotationExpr(new Name(annotationSimpleName), argument);
-    node.addAnnotation(annotationExpr);
+    node.getAnnotations().addFirst(annotationExpr);
   }
 }

--- a/injector/src/test/java/edu/ucr/cs/riple/injector/AnnotationWithArgumentTest.java
+++ b/injector/src/test/java/edu/ucr/cs/riple/injector/AnnotationWithArgumentTest.java
@@ -306,7 +306,8 @@ public class AnnotationWithArgumentTest extends BaseInjectorTest {
             "public class Super {",
             "   Object h = new Object();",
             "   @CustomNull({\"arg1\", \"arg2\"})",
-            "   @CustomNull(\"arg3\")",
+            "@CustomNull(\"arg3\")", // this is intentional, just to pass unit tests, this can be
+                                     // fixes by google java format.
             "   public void test(Object f) {",
             "      h = f;",
             "   }",

--- a/injector/src/test/java/edu/ucr/cs/riple/injector/AnnotationWithArgumentTest.java
+++ b/injector/src/test/java/edu/ucr/cs/riple/injector/AnnotationWithArgumentTest.java
@@ -307,7 +307,7 @@ public class AnnotationWithArgumentTest extends BaseInjectorTest {
             "   Object h = new Object();",
             "   @CustomNull({\"arg1\", \"arg2\"})",
             "@CustomNull(\"arg3\")", // this is intentional, just to pass unit tests, this can be
-                                     // fixes by google java format.
+            // fixes by google java format.
             "   public void test(Object f) {",
             "      h = f;",
             "   }",

--- a/injector/src/test/java/edu/ucr/cs/riple/injector/OnFieldInjectionTest.java
+++ b/injector/src/test/java/edu/ucr/cs/riple/injector/OnFieldInjectionTest.java
@@ -25,6 +25,7 @@
 package edu.ucr.cs.riple.injector;
 
 import edu.ucr.cs.riple.injector.changes.AddMarkerAnnotation;
+import edu.ucr.cs.riple.injector.changes.RemoveAnnotation;
 import edu.ucr.cs.riple.injector.location.OnField;
 import java.util.Collections;
 import org.junit.Test;
@@ -59,6 +60,83 @@ public class OnFieldInjectionTest extends BaseInjectorTest {
         .addChanges(
             new AddMarkerAnnotation(
                 new OnField("Super.java", "com.uber.Super", Collections.singleton("h")),
+                "javax.annotation.Nullable"))
+        .start();
+  }
+
+  @Test
+  public void addAndRemoveOnField() {
+    injectorTestHelper
+        .addInput(
+            "Super.java",
+            "package com.uber;",
+            "import org.hibernate.validator.constraints.NotEmpty;",
+            "public class Super {",
+            "   @Custom",
+            "   private @NotEmpty String foo;",
+            "}")
+        .expectOutput(
+            "package com.uber;",
+            "import javax.annotation.Nullable;",
+            "import org.hibernate.validator.constraints.NotEmpty;",
+            "public class Super {",
+            "   @Custom",
+            "   private @NotEmpty String foo;",
+            "}")
+        .addChanges(
+            new AddMarkerAnnotation(
+                new OnField("Super.java", "com.uber.Super", Collections.singleton("foo")),
+                "javax.annotation.Nullable"),
+            new RemoveAnnotation(
+                new OnField("Super.java", "com.uber.Super", Collections.singleton("foo")),
+                "javax.annotation.Nullable"))
+        .start(true);
+  }
+
+  @Test
+  public void addOnFieldWithTypeUseAnnotation() {
+    injectorTestHelper
+        .addInput(
+            "Super.java",
+            "package com.uber;",
+            "import org.hibernate.validator.constraints.NotEmpty;",
+            "public class Super {",
+            "   private @NotEmpty String foo;",
+            "}")
+        .expectOutput(
+            "package com.uber;",
+            "import javax.annotation.Nullable;",
+            "import org.hibernate.validator.constraints.NotEmpty;",
+            "public class Super {",
+            "   @Nullable private @NotEmpty String foo;",
+            "}")
+        .addChanges(
+            new AddMarkerAnnotation(
+                new OnField("Super.java", "com.uber.Super", Collections.singleton("foo")),
+                "javax.annotation.Nullable"))
+        .start();
+  }
+
+  @Test
+  public void addOnFieldWithTypeUseAnnotationWithOtherAnnotsExists() {
+    injectorTestHelper
+        .addInput(
+            "Super.java",
+            "package com.uber;",
+            "import org.hibernate.validator.constraints.NotEmpty;",
+            "public class Super {",
+            "   @JsonProperty private @NotEmpty Baz2 baz2;",
+            "}")
+        .expectOutput(
+            "package com.uber;",
+            "import javax.annotation.Nullable;",
+            "import org.hibernate.validator.constraints.NotEmpty;",
+            "public class Super {",
+            "   @Nullable @JsonProperty private @NotEmpty Baz2 baz2;",
+            "}")
+        .addChanges(
+            new AddMarkerAnnotation(
+                new OnField("Super.java", "com.uber.Super", Collections.singleton("baz2")),
                 "javax.annotation.Nullable"))
         .start();
   }


### PR DESCRIPTION
This PR partially resolves #78 by forcing the injecting annotation to be added at the beginning of the list of existing annotation. #78 will be resolved once the error is resolved upstream in `javaparser`.

Previously for input below:
```java
public class Super {
   @JsonProperty private @NotEmpty Baz2 baz2;,
}
```
We had:
```java
public class Super {
   @JsonProperty private@Nullable @NotEmpty Baz2 baz2;,
}
```

This output is wrong as we only intend to add declaration annotations and the annotation is mixed with the modifier, this is potentially confusing `LexicalPreservingPrinter` in iterations of adding/removing the annotation and removing the modifier. 

With this PR we will have the output below:
```java
public class Super {
    @Nullable @JsonProperty private @NotEmpty Baz2 baz2;
}
```