### PR TITLE
Add inference deactivation mode.

### DIFF
--- a/core/build.gradle
+++ b/core/build.gradle
@@ -50,7 +50,7 @@ tasks.test.dependsOn(':qual:publishToMavenLocal')
 
 // Set up environment variables for test configuration tu run with the latest development version.
 tasks.test.doFirst {
-    environment "NULLAWAY_TEST_VERSION", "0.10.2"
+    environment "NULLAWAY_TEST_VERSION", "0.10.0"
     environment "ANNOTATOR_VERSION", project.version
 }
 

--- a/core/build.gradle
+++ b/core/build.gradle
@@ -50,7 +50,7 @@ tasks.test.dependsOn(':qual:publishToMavenLocal')
 
 // Set up environment variables for test configuration tu run with the latest development version.
 tasks.test.doFirst {
-    environment "NULLAWAY_TEST_VERSION", "0.10.0"
+    environment "NULLAWAY_TEST_VERSION", "0.10.2"
     environment "ANNOTATOR_VERSION", project.version
 }
 

--- a/core/src/main/java/edu/ucr/cs/riple/core/log/Log.java
+++ b/core/src/main/java/edu/ucr/cs/riple/core/log/Log.java
@@ -24,6 +24,11 @@
 
 package edu.ucr.cs.riple.core.log;
 
+import edu.ucr.cs.riple.injector.changes.AddAnnotation;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Set;
+
 /** Log information for Annotator. */
 public class Log {
 
@@ -39,12 +44,19 @@ public class Log {
   /** Total time spent in building targets. */
   private long buildTime = 0;
 
+  /**
+   * Set of approved and injected annotations. These annotations are evaluated and approved and will
+   * not get removed from the source code.
+   */
+  private final List<AddAnnotation> injectedAnnotations = new ArrayList<>();
+
   /** Resets all log information. */
   public void reset() {
     this.nodes = 0;
     this.requested = 0;
     this.totalTime = 0;
     this.buildTime = 0;
+    this.injectedAnnotations.clear();
   }
 
   @Override
@@ -101,5 +113,23 @@ public class Log {
    */
   public void updateNodeNumber(long numberOfNewNodesCreated) {
     this.nodes += numberOfNewNodesCreated;
+  }
+
+  /**
+   * Updates list of injected annotations with the latest injected annotations.
+   *
+   * @param annotations List of the latest injected annotations.
+   */
+  public void updateInjectedAnnotations(Set<AddAnnotation> annotations) {
+    this.injectedAnnotations.addAll(annotations);
+  }
+
+  /**
+   * Returns list of injected annotations.
+   *
+   * @return List of injected annotations.
+   */
+  public List<AddAnnotation> getInjectedAnnotations() {
+    return injectedAnnotations;
   }
 }

--- a/core/src/test/java/edu/ucr/cs/riple/core/CoreTest.java
+++ b/core/src/test/java/edu/ucr/cs/riple/core/CoreTest.java
@@ -27,6 +27,7 @@ package edu.ucr.cs.riple.core;
 import static com.google.common.collect.Sets.newHashSet;
 import static java.util.Collections.singleton;
 
+import com.google.common.base.Preconditions;
 import edu.ucr.cs.riple.core.tools.TReport;
 import edu.ucr.cs.riple.injector.location.OnField;
 import edu.ucr.cs.riple.injector.location.OnMethod;
@@ -245,5 +246,32 @@ public class CoreTest extends BaseCoreTest {
         .addExpectedReports(
             new TReport(new OnMethod("Main.java", "test.Main$1", "apply(java.lang.Object)"), -1))
         .start();
+  }
+
+  @Test
+  public void deactivateInferenceTest() {
+    coreTestHelper
+        .addInputLines(
+            "Main.java",
+            "package test;",
+            "public class Main {",
+            "   public Object run() {",
+            "     return null;",
+            "   }",
+            "}")
+        .toDepth(1)
+        .deactivateInference()
+        .start();
+    // Verify that only one @NullUnmarked annotation is injected (No @Nullable injection).
+    Preconditions.checkArgument(
+        coreTestHelper.getConfig().log.getInjectedAnnotations().size() == 1);
+    Preconditions.checkArgument(
+        coreTestHelper
+            .getConfig()
+            .log
+            .getInjectedAnnotations()
+            .get(0)
+            .annotation
+            .equals("org.jspecify.nullness.NullUnmarked"));
   }
 }

--- a/core/src/test/java/edu/ucr/cs/riple/core/tools/CoreTestHelper.java
+++ b/core/src/test/java/edu/ucr/cs/riple/core/tools/CoreTestHelper.java
@@ -65,6 +65,7 @@ public class CoreTestHelper {
   private boolean disableBailout = false;
   private boolean forceResolveActivated = false;
   private boolean downstreamDependencyAnalysisActivated = false;
+  private boolean deactivateInference = false;
   private AnalysisMode mode = AnalysisMode.LOCAL;
   private Config config;
 
@@ -142,6 +143,12 @@ public class CoreTestHelper {
   }
 
   public CoreTestHelper enableForceResolve() {
+    this.forceResolveActivated = true;
+    return this;
+  }
+
+  public CoreTestHelper deactivateInference() {
+    this.deactivateInference = true;
     this.forceResolveActivated = true;
     return this;
   }
@@ -269,6 +276,7 @@ public class CoreTestHelper {
     builder.optimized = true;
     builder.downStreamDependenciesAnalysisActivated = downstreamDependencyAnalysisActivated;
     builder.mode = mode;
+    builder.inferenceActivated = !deactivateInference;
     builder.forceResolveActivation = forceResolveActivated;
     if (downstreamDependencyAnalysisActivated) {
       builder.buildCommand =


### PR DESCRIPTION
This PR resolves #86 by adding the specific analysis mode which deactivates inference of Annotator and all errors are resolved with `@NullUnmarked` annotations.

To enable this feature flag below must be passed:
```shell
-di, --deactivate-inference
```

Or 
```json
"INFERENCE_ACTIVATION": false
```

Please note: When inference is deactivated, force resolve mode is automatically activated to resolve all remaining errors with `@NullUnmarked` injection.
-----