### PR TITLE
Rename methods in injector

### DIFF
--- a/core/src/main/java/edu/ucr/cs/riple/core/injectors/PhysicalInjector.java
+++ b/core/src/main/java/edu/ucr/cs/riple/core/injectors/PhysicalInjector.java
@@ -42,11 +42,11 @@ public class PhysicalInjector extends AnnotationInjector {
 
   @Override
   public void removeAnnotations(Set<RemoveAnnotation> changes) {
-    this.injector.addAnnotations(changes);
+    this.injector.removeAnnotations(changes);
   }
 
   @Override
   public void injectAnnotations(Set<AddAnnotation> changes) {
-    this.injector.removeAnnotations(changes);
+    this.injector.addAnnotations(changes);
   }
 }

--- a/injector/src/main/java/edu/ucr/cs/riple/injector/Injector.java
+++ b/injector/src/main/java/edu/ucr/cs/riple/injector/Injector.java
@@ -51,11 +51,11 @@ public class Injector {
     return report;
   }
 
-  public Report addAnnotations(Set<RemoveAnnotation> requests) {
+  public Report addAnnotations(Set<AddAnnotation> requests) {
     return this.start(new WorkListBuilder<>(requests).getWorkLists(), false);
   }
 
-  public Report removeAnnotations(Set<AddAnnotation> requests) {
+  public Report removeAnnotations(Set<RemoveAnnotation> requests) {
     return this.start(new WorkListBuilder<>(requests).getWorkLists(), false);
   }
 


### PR DESCRIPTION
This PR simply renames methods used in calling injector APIs. It was not introducing any bugs even though with wrong API names the correct code was still executing.


#### Note
This is merely a rename of methods. I am going to land this one for now, please let me know if there is anything you would like to change here and I will bring this back.