### PR TITLE
Fix URIs in MethodDeclarationTree nodes

### DIFF
--- a/type-annotator-scanner/src/main/java/edu/ucr/cs/riple/scanner/TypeAnnotatorScanner.java
+++ b/type-annotator-scanner/src/main/java/edu/ucr/cs/riple/scanner/TypeAnnotatorScanner.java
@@ -106,9 +106,10 @@ public class TypeAnnotatorScanner extends BugChecker
       return Description.NO_MATCH;
     }
     Symbol.MethodSymbol methodSymbol = ASTHelpers.getSymbol(tree);
-    MethodInfo methodInfo = MethodInfo.findOrCreate(methodSymbol, state, context);
+    MethodInfo methodInfo = MethodInfo.findOrCreate(methodSymbol, context);
     methodInfo.findParent(state, context);
     methodInfo.setAnnotation(config);
+    methodInfo.setURI(state);
     List<Boolean> paramAnnotations = new ArrayList<>();
     for (int i = 0; i < methodSymbol.getParameters().size(); i++) {
       paramAnnotations.add(SymbolUtil.paramHasNullableAnnotation(methodSymbol, i, config));

--- a/type-annotator-scanner/src/main/java/edu/ucr/cs/riple/scanner/out/MethodInfo.java
+++ b/type-annotator-scanner/src/main/java/edu/ucr/cs/riple/scanner/out/MethodInfo.java
@@ -110,7 +110,8 @@ public class MethodInfo {
         String.valueOf(hasNullableAnnotation),
         getVisibilityOfMethod(),
         String.valueOf(!symbol.getReturnType().isPrimitiveOrVoid()),
-        uri.toString());
+        // for build systems that might return null for bytecodes.
+        (uri != null ? uri.toString() : "null"));
   }
 
   public static String header() {


### PR DESCRIPTION
This PR resolves #93 by passing the relevant `VisitorState` for fetching the `URI`.


#### Note
This will enable to Annotator to correctly add `@NullUnmarked` annotations as generating annotation requests requires getting URIs from `MethodDeclarationTree`.