### PR TITLE
Release scripts

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -20,18 +20,10 @@
  * THE SOFTWARE.
  */
 import net.ltgt.gradle.errorprone.CheckSeverity
-buildscript {
-    repositories {
-        mavenCentral()
-    }
-
-    dependencies {
-        classpath 'com.vanniktech:gradle-maven-publish-plugin:0.14.2'
-    }
-}
 
 plugins{
     id "net.ltgt.errorprone" version "2.0.1" apply false
+    id "com.vanniktech.maven.publish" version "0.22.0"
 }
 
 allprojects {

--- a/core/build.gradle
+++ b/core/build.gradle
@@ -27,6 +27,7 @@ plugins {
     id 'com.github.johnrengelman.shadow' version '7.1.2'
     id 'maven-publish'
     id 'application'
+    id "com.vanniktech.maven.publish"
 }
 
 application {
@@ -60,6 +61,12 @@ publishing {
             project.shadow.component(publication)
         }
     }
+
+    mavenPublishing {
+        publishToMavenCentral(SonatypeHost.S01)
+        signAllPublications()
+    }
+
     repositories {
         mavenLocal()
     }

--- a/core/build.gradle
+++ b/core/build.gradle
@@ -22,6 +22,8 @@
  * THE SOFTWARE.
  */
 
+import com.vanniktech.maven.publish.SonatypeHost
+
 plugins {
     id 'com.github.sherter.google-java-format' version '0.9'
     id 'com.github.johnrengelman.shadow' version '7.1.2'

--- a/gradle.properties
+++ b/gradle.properties
@@ -23,3 +23,18 @@
 
 GROUP=edu.ucr.cs.riple.nullawayannotator
 VERSION_NAME=1.3.4-SNAPSHOT
+
+POM_DESCRIPTION=A tool that automatically fixes source code to pass NullAway checks.
+
+POM_URL=https://github.com/ucr-riple/NullAwayAnnotator
+POM_SCM_URL=https://github.com/ucr-riple/NullAwayAnnotator
+POM_SCM_CONNECTION=scm:git:git://github.com/ucr-riple/NullAwayAnnotator
+POM_SCM_DEV_CONNECTION=scm:git:ssh://git@github.com:ucr-riple/NullAwayAnnotator.git
+
+POM_LICENCE_NAME=The MIT License
+POM_LICENCE_URL=https://opensource.org/licenses/MIT
+POM_LICENCE_DIST=repo
+
+POM_DEVELOPER_ID=ucr-riple
+POM_DEVELOPER_NAME=PLSE research at UC Riverside
+POM_DEVELOPER_URL=https://riple.cs.ucr.edu

--- a/injector/build.gradle
+++ b/injector/build.gradle
@@ -45,6 +45,3 @@ googleJavaFormat {
     // don't enforce formatting for generated Java code under buildSrc
     exclude 'tests/**/*.java'
 }
-
-apply plugin: 'com.vanniktech.maven.publish'
-

--- a/qual/build.gradle
+++ b/qual/build.gradle
@@ -36,6 +36,3 @@ buildscript {
 plugins {
     id 'com.github.sherter.google-java-format' version '0.9'
 }
-
-apply plugin: 'com.vanniktech.maven.publish'
-

--- a/qual/build.gradle
+++ b/qual/build.gradle
@@ -36,3 +36,6 @@ buildscript {
 plugins {
     id 'com.github.sherter.google-java-format' version '0.9'
 }
+
+// Need to publish it to maven local for unit tests
+apply plugin: 'com.vanniktech.maven.publish'

--- a/type-annotator-scanner/build.gradle
+++ b/type-annotator-scanner/build.gradle
@@ -22,6 +22,8 @@
  * THE SOFTWARE.
  */
 
+import com.vanniktech.maven.publish.SonatypeHost
+
 buildscript {
     repositories {
         mavenCentral()

--- a/type-annotator-scanner/build.gradle
+++ b/type-annotator-scanner/build.gradle
@@ -36,9 +36,9 @@ buildscript {
 plugins {
     id "net.ltgt.errorprone" version "2.0.1" apply false
     id 'com.github.sherter.google-java-format' version '0.9'
+    id 'maven-publish'
+    id "com.vanniktech.maven.publish"
 }
-
-apply plugin: 'com.vanniktech.maven.publish'
 
 dependencies {
     compileOnly deps.apt.autoServiceAnnot
@@ -46,4 +46,11 @@ dependencies {
     compileOnly deps.build.errorProneCheckApi
 
     testImplementation deps.test.errorProneTestHelpers
+}
+
+publishing {
+    mavenPublishing {
+        publishToMavenCentral(SonatypeHost.S01)
+        signAllPublications()
+    }
 }


### PR DESCRIPTION
This PR adds release configurations for `core` and `type-annotator-scanner` modules.


Note: `core` will be renamed to `annotator-core` as a followup.