### PR TITLE
Bug fix for Injector test infrastructure

### DIFF
--- a/injector/build.gradle
+++ b/injector/build.gradle
@@ -44,4 +44,6 @@ compileJava.mustRunAfter verifyGoogleJavaFormat
 googleJavaFormat {
     // don't enforce formatting for generated Java code under buildSrc
     exclude 'tests/**/*.java'
+    // tests expected output does not conform to google java format rules.
+    exclude '**/test/resources/**/*.java'
 }

--- a/injector/src/main/java/edu/ucr/cs/riple/injector/Helper.java
+++ b/injector/src/main/java/edu/ucr/cs/riple/injector/Helper.java
@@ -159,7 +159,7 @@ public class Helper {
   }
 
   /**
-   * Locates the inner class with the given name at specific index.
+   * Locates the non-direct inner class with the given name at specific index.
    *
    * @param cursor Starting node for traversal.
    * @param name name of the inner class.
@@ -167,10 +167,16 @@ public class Helper {
    * @return inner class with the given name and index.
    * @throws TargetClassNotFound if the target class is not found.
    */
-  private static Node findInnerClass(Node cursor, String name, int index)
+  private static Node findNonDirectInnerClass(Node cursor, String name, int index)
       throws TargetClassNotFound {
     final List<Node> candidates = new ArrayList<>();
-    walk(cursor, candidates, node -> isDeclarationWithName(node, name));
+    walk(
+        cursor,
+        candidates,
+        node ->
+            isDeclarationWithName(node, name)
+                && node.getParentNode().isPresent()
+                && !node.getParentNode().get().equals(cursor));
     if (index >= candidates.size()) {
       throw new TargetClassNotFound("Non-Direct-Inner-Class", index + name, cursor);
     }
@@ -296,7 +302,7 @@ public class Helper {
         cursor =
             indexString.equals("")
                 ? findDirectInnerClass(cursor, actualName)
-                : findInnerClass(cursor, actualName, index);
+                : findNonDirectInnerClass(cursor, actualName, index);
       }
     }
     return getMembersOfNode(cursor);

--- a/injector/src/main/java/edu/ucr/cs/riple/injector/Printer.java
+++ b/injector/src/main/java/edu/ucr/cs/riple/injector/Printer.java
@@ -86,7 +86,7 @@ public class Printer {
       return;
     }
     int line = findStartOffsetForImports(tree);
-    imports.forEach(importDec -> lines.add(line, importDec.toString()));
+    imports.forEach(importDec -> lines.add(line, importDec.toString().strip()));
   }
 
   /**

--- a/injector/src/test/java/edu/ucr/cs/riple/injector/LexicalPreservationTest.java
+++ b/injector/src/test/java/edu/ucr/cs/riple/injector/LexicalPreservationTest.java
@@ -244,7 +244,7 @@ public class LexicalPreservationTest extends BaseInjectorTest {
             "package com.uber;",
             "public class Super {",
             "   Object test() {",
-            "       init(this.new NodeVisitor(), this.new EdgeVisitor());\n",
+            "       init(this.new NodeVisitor(), this.new EdgeVisitor());",
             "       return foo(this.new Bar(), this.new Foo(), getBuilder().new Foo());",
             "   }",
             "   Object foo(Bar b, Foo f) {",

--- a/injector/src/test/java/edu/ucr/cs/riple/injector/OnParameterInjectionTest.java
+++ b/injector/src/test/java/edu/ucr/cs/riple/injector/OnParameterInjectionTest.java
@@ -127,7 +127,6 @@ public class OnParameterInjectionTest extends BaseInjectorTest {
             "   int exception,",
             "   CallSiteReference site,",
             "   @Nullable BootstrapMethod bootstrap);",
-            "",
             "SSAAbstractInvokeInstruction InvokeInstruction(",
             "   int index, int[] params, int exception, CallSiteReference site, BootstrapMethod bootstrap);",
             "}")

--- a/injector/src/test/java/edu/ucr/cs/riple/injector/tools/InjectorTestHelper.java
+++ b/injector/src/test/java/edu/ucr/cs/riple/injector/tools/InjectorTestHelper.java
@@ -58,6 +58,7 @@ public class InjectorTestHelper {
 
   public InjectorTestHelperOutput addInputSourceFile(String path, String inputFilePath) {
     writeToFile(pathOf(rootPath.resolve("src"), path), readLinesOfFileFromResource(inputFilePath));
+    files.add(path);
     return new InjectorTestHelperOutput(this, rootPath, path);
   }
 
@@ -84,17 +85,11 @@ public class InjectorTestHelper {
         String found =
             FileUtils.readFileToString(
                 pathOf(rootPath.resolve("src"), key).toFile(), Charset.defaultCharset());
-        // Lexical Preserving Printer adds new lines that will be reverted by calling google java
-        // format, therefore we skip them in tests not cause test failures.
-        String trimmedFound = Utility.removeNewLines(found);
         String expected =
             FileUtils.readFileToString(
                 pathOf(rootPath.resolve("expected"), key).toFile(), Charset.defaultCharset());
-        String trimmedExpected = Utility.removeNewLines(expected);
-        if (!trimmedFound.equals(trimmedExpected)) {
-          System.out.println("FOUND   : " + trimmedFound);
-          System.out.println("EXPECTED: " + trimmedExpected);
-          fail("\nExpected:\n" + expected + "\n\nBut found:\n" + found + "\n");
+        if (!expected.equals(found)) {
+          fail("Expected:\n" + expected + "\nBut found:\n" + found);
         }
       } catch (IOException e) {
         throw new RuntimeException(e);

--- a/injector/src/test/resources/benchmark_expected_10.java
+++ b/injector/src/test/resources/benchmark_expected_10.java
@@ -67,7 +67,8 @@ public class Main {
                         class Helper { // injector.Main$1$2$1$2Helper
                           Object f7;
                           final Comp c = new Comp() { // injector.Main$1$2$1$2Helper$1
-                                @Nullable Object f8;
+                                @Nullable
+                                Object f8;
 
                                 @Override
                                 public Object compare() {

--- a/injector/src/test/resources/benchmark_expected_11.java
+++ b/injector/src/test/resources/benchmark_expected_11.java
@@ -78,7 +78,8 @@ public class Main {
                       }
 
                       class Helper { // injector.Main$1$2$1$Helper
-                        @Nullable Object f9;
+                        @Nullable
+                        Object f9;
                         final Comp c = new Comp() { // injector.Main$1$2$1$Helper$1
                               Object f10;
 

--- a/injector/src/test/resources/benchmark_expected_12.java
+++ b/injector/src/test/resources/benchmark_expected_12.java
@@ -80,7 +80,8 @@ public class Main {
                       class Helper { // injector.Main$1$2$1$Helper
                         Object f9;
                         final Comp c = new Comp() { // injector.Main$1$2$1$Helper$1
-                              @Nullable Object f10;
+                              @Nullable
+                              Object f10;
 
                               @Override
                               public Object compare() {

--- a/injector/src/test/resources/benchmark_expected_13.java
+++ b/injector/src/test/resources/benchmark_expected_13.java
@@ -90,7 +90,8 @@ public class Main {
                       }
                     };
                 class Helper { // injector.Main$1$2$1Helper
-                  @Nullable Object f11;
+                  @Nullable
+                  Object f11;
                   final Comp c = new Comp() { // injector.Main$1$2$1Helper$1
                         Object f12;
 

--- a/injector/src/test/resources/benchmark_expected_14.java
+++ b/injector/src/test/resources/benchmark_expected_14.java
@@ -92,7 +92,8 @@ public class Main {
                 class Helper { // injector.Main$1$2$1Helper
                   Object f11;
                   final Comp c = new Comp() { // injector.Main$1$2$1Helper$1
-                        @Nullable Object f12;
+                        @Nullable
+                        Object f12;
 
                         @Override
                         public Object compare() {

--- a/injector/src/test/resources/benchmark_expected_15.java
+++ b/injector/src/test/resources/benchmark_expected_15.java
@@ -113,7 +113,8 @@ public class Main {
       };
 
   Run c1 = new Run() { // injector.Main$2
-        @Nullable Object f13;
+        @Nullable
+        Object f13;
 
         @Override
         public Object exec(@Nullable Object o) {

--- a/injector/src/test/resources/benchmark_expected_16.java
+++ b/injector/src/test/resources/benchmark_expected_16.java
@@ -123,7 +123,8 @@ public class Main {
 
   public void foo() {
     class Helper { // injector.Main$1Helper
-      @Nullable Object f14;
+      @Nullable
+      Object f14;
 
       class InnerHelper { // injector.Main$1Helper$InnerHelper
         Object f15;

--- a/injector/src/test/resources/benchmark_expected_18.java
+++ b/injector/src/test/resources/benchmark_expected_18.java
@@ -138,7 +138,8 @@ public class Main {
           return null;
         } else {
           return new Comp() { // injector.Main$1Helper$1
-            @Nullable Object f16;
+            @Nullable
+            Object f16;
 
             @Override
             public Object compare() {

--- a/injector/src/test/resources/benchmark_expected_19.java
+++ b/injector/src/test/resources/benchmark_expected_19.java
@@ -151,7 +151,8 @@ public class Main {
 
     executeRunner(
         new Run() { // injector.Main$3
-          @Nullable Object f17;
+          @Nullable
+          Object f17;
 
           @Override
           public Object exec(@Nullable Object o) {

--- a/injector/src/test/resources/benchmark_expected_20.java
+++ b/injector/src/test/resources/benchmark_expected_20.java
@@ -162,7 +162,8 @@ public class Main {
 
   public void foo1() {
     class Helper { // injector.Main$2Helper
-      @Nullable Object f18;
+      @Nullable
+      Object f18;
 
       Object bar(boolean b) {
         return null;

--- a/injector/src/test/resources/benchmark_expected_21.java
+++ b/injector/src/test/resources/benchmark_expected_21.java
@@ -172,7 +172,8 @@ public class Main {
 
   public void foo2() {
     class Helper { // injector.Main$3Helper
-      @Nullable Object f19;
+      @Nullable
+      Object f19;
 
       Object bar(boolean b) {
         return null;

--- a/injector/src/test/resources/benchmark_expected_3.java
+++ b/injector/src/test/resources/benchmark_expected_3.java
@@ -25,7 +25,8 @@ public class Main {
   }
 
   Run c = new Run() { // injector.Main$1
-        @Nullable Object f1;
+        @Nullable
+        Object f1;
         final Comp outerComp = new Comp() { // injector.Main$1$1
               Object f2;
 

--- a/injector/src/test/resources/benchmark_expected_4.java
+++ b/injector/src/test/resources/benchmark_expected_4.java
@@ -29,8 +29,8 @@ public class Main {
         final Comp outerComp = new Comp() { // injector.Main$1$1
               Object f2;
 
-              @Override
               @Nullable
+              @Override
               public Object compare() {
                 return null;
               }

--- a/injector/src/test/resources/benchmark_expected_5.java
+++ b/injector/src/test/resources/benchmark_expected_5.java
@@ -41,7 +41,8 @@ public class Main {
             return null;
           } else {
             return new Comp() { // injector.Main$1$2
-              @Nullable Object f3;
+              @Nullable
+              Object f3;
 
               public Object inner() {
                 Comp c = new Comp() { // injector.Main$1$2$1

--- a/injector/src/test/resources/benchmark_expected_6.java
+++ b/injector/src/test/resources/benchmark_expected_6.java
@@ -45,7 +45,8 @@ public class Main {
 
               public Object inner() {
                 Comp c = new Comp() { // injector.Main$1$2$1
-                      @Nullable Object f4;
+                      @Nullable
+                      Object f4;
 
                       @Override
                       public Object compare() {

--- a/injector/src/test/resources/benchmark_expected_7.java
+++ b/injector/src/test/resources/benchmark_expected_7.java
@@ -50,7 +50,8 @@ public class Main {
                       @Override
                       public Object compare() {
                         class Helper { // injector.Main$1$2$1$1Helper
-                          @Nullable Object f5;
+                          @Nullable
+                          Object f5;
                           final Comp c = new Comp() { // injector.Main$1$2$1$1Helper$1
                                 Object f6;
 

--- a/injector/src/test/resources/benchmark_expected_8.java
+++ b/injector/src/test/resources/benchmark_expected_8.java
@@ -52,7 +52,8 @@ public class Main {
                         class Helper { // injector.Main$1$2$1$1Helper
                           Object f5;
                           final Comp c = new Comp() { // injector.Main$1$2$1$1Helper$1
-                                @Nullable Object f6;
+                                @Nullable
+                                Object f6;
 
                                 @Override
                                 public Object compare() {

--- a/injector/src/test/resources/benchmark_expected_9.java
+++ b/injector/src/test/resources/benchmark_expected_9.java
@@ -65,7 +65,8 @@ public class Main {
 
                       public void anotherHelper() {
                         class Helper { // injector.Main$1$2$1$2Helper
-                          @Nullable Object f7;
+                          @Nullable
+                          Object f7;
                           final Comp c = new Comp() { // injector.Main$1$2$1$2Helper$1
                                 Object f8;
 

--- a/injector/src/test/resources/simple_expected_1.java
+++ b/injector/src/test/resources/simple_expected_1.java
@@ -1,12 +1,12 @@
 package injector;
-
 import javax.annotation.Nullable;
 
 public class Main {
 
   public void foo1() {
     class Helper {
-      @Nullable Object f1;
+      @Nullable
+      Object f1;
     }
   }
 

--- a/injector/src/test/resources/simple_expected_2.java
+++ b/injector/src/test/resources/simple_expected_2.java
@@ -1,5 +1,4 @@
 package injector;
-
 import javax.annotation.Nullable;
 
 public class Main {
@@ -11,7 +10,8 @@ public class Main {
   }
 
   class Helper {
-    @Nullable Object f0;
+    @Nullable
+    Object f0;
   }
 
   public void foo() {

--- a/injector/src/test/resources/simple_expected_3.java
+++ b/injector/src/test/resources/simple_expected_3.java
@@ -1,5 +1,4 @@
 package injector;
-
 import javax.annotation.Nullable;
 
 public class Main {
@@ -16,7 +15,8 @@ public class Main {
 
   public void foo() {
     class Helper {
-      @Nullable Object f2;
+      @Nullable
+      Object f2;
     }
   }
 }


### PR DESCRIPTION
Due to a bug in injector test infra, tests in `ClassSearchTest` were excluded from CI. This PR adds these tests back.

The expected output of these tests had to be updated as before #90 tests outputs were compared to their expected output regardless of existing white spaces. But after #90 and #102, we used a stricter way to compare the expected output (tools output must match the expected output byte to byte), therefore the expected output of these tests had been updated as well.


@msridhar @lazaroclapp This is a straightforward change and it mostly contains updating expected output results of tests (updating white spaces), therefore I am going to land this now, please let me know if there is anything you would like to discuss and I will bring this back.