### PR TITLE
Extract AnnotatorScanner config writer into a separate class.

### DIFF
--- a/annotator-core/src/main/java/edu/ucr/cs/riple/core/util/Utility.java
+++ b/annotator-core/src/main/java/edu/ucr/cs/riple/core/util/Utility.java
@@ -32,6 +32,7 @@ import edu.ucr.cs.riple.core.metadata.index.Error;
 import edu.ucr.cs.riple.core.metadata.index.Factory;
 import edu.ucr.cs.riple.core.metadata.index.Fix;
 import edu.ucr.cs.riple.scanner.AnnotatorScanner;
+import edu.ucr.cs.riple.scanner.ScannerConfigWriter;
 import java.io.BufferedReader;
 import java.io.BufferedWriter;
 import java.io.File;
@@ -262,54 +263,14 @@ public class Utility {
    * @param activation activation flag for all features of the scanner.
    */
   public static void setScannerCheckerActivation(ModuleInfo info, boolean activation) {
-    DocumentBuilderFactory docFactory = DocumentBuilderFactory.newInstance();
-    try {
-      DocumentBuilder docBuilder = docFactory.newDocumentBuilder();
-      Document doc = docBuilder.newDocument();
-
-      // Root
-      Element rootElement = doc.createElement("scanner");
-      doc.appendChild(rootElement);
-
-      // Method
-      Element methodElement = doc.createElement("method");
-      methodElement.setAttribute("active", String.valueOf(activation));
-      rootElement.appendChild(methodElement);
-
-      // Field
-      Element fieldElement = doc.createElement("field");
-      fieldElement.setAttribute("active", String.valueOf(activation));
-      rootElement.appendChild(fieldElement);
-
-      // Call
-      Element callElement = doc.createElement("call");
-      callElement.setAttribute("active", String.valueOf(activation));
-      rootElement.appendChild(callElement);
-
-      // File
-      Element classElement = doc.createElement("class");
-      classElement.setAttribute("active", String.valueOf(activation));
-      rootElement.appendChild(classElement);
-
-      // Output dir
-      Element outputDir = doc.createElement("path");
-      outputDir.setTextContent(info.dir.toString());
-      rootElement.appendChild(outputDir);
-
-      // UUID
-      Element uuid = doc.createElement("uuid");
-      uuid.setTextContent(UUID.randomUUID().toString());
-      rootElement.appendChild(uuid);
-
-      // Writings
-      TransformerFactory transformerFactory = TransformerFactory.newInstance();
-      Transformer transformer = transformerFactory.newTransformer();
-      DOMSource source = new DOMSource(doc);
-      StreamResult result = new StreamResult(info.scannerConfig.toFile());
-      transformer.transform(source, result);
-    } catch (ParserConfigurationException | TransformerException e) {
-      throw new RuntimeException("Error happened in writing config.", e);
-    }
+    ScannerConfigWriter writer = new ScannerConfigWriter();
+    writer
+        .setCallTrackerActivation(activation)
+        .setClassTrackerActivation(activation)
+        .setFieldTrackerActivation(activation)
+        .setMethodTrackerActivation(activation)
+        .setOutput(info.dir)
+        .writeAsXML(info.scannerConfig);
   }
 
   /**

--- a/annotator-scanner/src/main/java/edu/ucr/cs/riple/scanner/Config.java
+++ b/annotator-scanner/src/main/java/edu/ucr/cs/riple/scanner/Config.java
@@ -24,19 +24,8 @@
 
 package edu.ucr.cs.riple.scanner;
 
-import com.google.common.base.Preconditions;
 import java.nio.file.Path;
 import javax.annotation.Nonnull;
-import javax.xml.parsers.DocumentBuilder;
-import javax.xml.parsers.DocumentBuilderFactory;
-import javax.xml.parsers.ParserConfigurationException;
-import javax.xml.transform.Transformer;
-import javax.xml.transform.TransformerException;
-import javax.xml.transform.TransformerFactory;
-import javax.xml.transform.dom.DOMSource;
-import javax.xml.transform.stream.StreamResult;
-import org.w3c.dom.Document;
-import org.w3c.dom.Element;
 
 /** Config of scanner. */
 public interface Config {
@@ -83,103 +72,4 @@ public interface Config {
    */
   @Nonnull
   Path getOutputDirectory();
-
-  /** Builder for setting a AnnotatorScanner configuration and output in XML format. */
-  class Builder {
-
-    /** Path to output directory. */
-    private Path outputDirectory;
-    /** Controls method info serialization. */
-    private boolean methodTrackerIsActive;
-    /** Controls field usage info serialization. */
-    private boolean fieldTrackerIsActive;
-    /** Controls method invocation serialization. */
-    private boolean callTrackerIsActive;
-    /** Controls class info serialization. */
-    private boolean classTrackerIsActive;
-
-    public Builder() {
-      this.methodTrackerIsActive = false;
-      this.fieldTrackerIsActive = false;
-      this.callTrackerIsActive = false;
-      this.classTrackerIsActive = false;
-    }
-
-    public Builder setOutput(Path output) {
-      this.outputDirectory = output;
-      return this;
-    }
-
-    public Builder setMethodTrackerActivation(boolean activation) {
-      this.methodTrackerIsActive = activation;
-      return this;
-    }
-
-    public Builder setFieldTrackerActivation(boolean activation) {
-      this.fieldTrackerIsActive = activation;
-      return this;
-    }
-
-    public Builder setCallTrackerActivation(boolean activation) {
-      this.callTrackerIsActive = activation;
-      return this;
-    }
-
-    public Builder setClassTrackerActivation(boolean activation) {
-      this.classTrackerIsActive = activation;
-      return this;
-    }
-
-    /**
-     * Outputs the configured object as XML format in the given path.
-     *
-     * @param path Output path.
-     */
-    public void writeAsXML(Path path) {
-      Preconditions.checkNotNull(this.outputDirectory, "Output directory must be initialized.");
-      DocumentBuilderFactory docFactory = DocumentBuilderFactory.newInstance();
-      try {
-        DocumentBuilder docBuilder = docFactory.newDocumentBuilder();
-        Document doc = docBuilder.newDocument();
-
-        // Root
-        Element rootElement = doc.createElement("scanner");
-        doc.appendChild(rootElement);
-
-        // Method
-        Element methodElement = doc.createElement("method");
-        methodElement.setAttribute("active", String.valueOf(methodTrackerIsActive));
-        rootElement.appendChild(methodElement);
-
-        // Field
-        Element fieldElement = doc.createElement("field");
-        fieldElement.setAttribute("active", String.valueOf(fieldTrackerIsActive));
-        rootElement.appendChild(fieldElement);
-
-        // Call
-        Element callElement = doc.createElement("call");
-        callElement.setAttribute("active", String.valueOf(callTrackerIsActive));
-        rootElement.appendChild(callElement);
-
-        // File
-        Element classElement = doc.createElement("class");
-        classElement.setAttribute("active", String.valueOf(classTrackerIsActive));
-        rootElement.appendChild(classElement);
-
-        // Output dir
-        Element outputDir = doc.createElement("path");
-        outputDir.setTextContent(this.outputDirectory.toString());
-        rootElement.appendChild(outputDir);
-
-        // Writings
-        TransformerFactory transformerFactory = TransformerFactory.newInstance();
-        Transformer transformer = transformerFactory.newTransformer();
-        DOMSource source = new DOMSource(doc);
-        StreamResult result = new StreamResult(path.toFile());
-        transformer.transform(source, result);
-      } catch (ParserConfigurationException | TransformerException e) {
-        throw new RuntimeException("Error happened in writing config.", e);
-      }
-    }
-  }
 }

--- a/annotator-scanner/src/main/java/edu/ucr/cs/riple/scanner/ScannerConfigWriter.java
+++ b/annotator-scanner/src/main/java/edu/ucr/cs/riple/scanner/ScannerConfigWriter.java
@@ -1,0 +1,148 @@
+/*
+ * MIT License
+ *
+ * Copyright (c) 2022 Nima Karimipour
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+package edu.ucr.cs.riple.scanner;
+
+import com.google.common.base.Preconditions;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.UUID;
+import javax.xml.parsers.DocumentBuilder;
+import javax.xml.parsers.DocumentBuilderFactory;
+import javax.xml.parsers.ParserConfigurationException;
+import javax.xml.transform.Transformer;
+import javax.xml.transform.TransformerException;
+import javax.xml.transform.TransformerFactory;
+import javax.xml.transform.dom.DOMSource;
+import javax.xml.transform.stream.StreamResult;
+import org.w3c.dom.Document;
+import org.w3c.dom.Element;
+
+/** Writer for creating an AnnotatorScanner configuration and output it in XML format. */
+public class ScannerConfigWriter {
+
+  /** Path to output directory. */
+  private Path outputDirectory;
+  /** Controls method info serialization. */
+  private boolean methodTrackerIsActive;
+  /** Controls field usage info serialization. */
+  private boolean fieldTrackerIsActive;
+  /** Controls method invocation serialization. */
+  private boolean callTrackerIsActive;
+  /** Controls class info serialization. */
+  private boolean classTrackerIsActive;
+
+  public ScannerConfigWriter() {
+    this.methodTrackerIsActive = false;
+    this.fieldTrackerIsActive = false;
+    this.callTrackerIsActive = false;
+    this.classTrackerIsActive = false;
+  }
+
+  public ScannerConfigWriter setOutput(Path output) {
+    this.outputDirectory = output;
+    return this;
+  }
+
+  public ScannerConfigWriter setMethodTrackerActivation(boolean activation) {
+    this.methodTrackerIsActive = activation;
+    return this;
+  }
+
+  public ScannerConfigWriter setFieldTrackerActivation(boolean activation) {
+    this.fieldTrackerIsActive = activation;
+    return this;
+  }
+
+  public ScannerConfigWriter setCallTrackerActivation(boolean activation) {
+    this.callTrackerIsActive = activation;
+    return this;
+  }
+
+  public ScannerConfigWriter setClassTrackerActivation(boolean activation) {
+    this.classTrackerIsActive = activation;
+    return this;
+  }
+
+  /**
+   * Outputs the configured object as XML format in the given path.
+   *
+   * @param path Output path.
+   */
+  public void writeAsXML(Path path) {
+    Preconditions.checkNotNull(this.outputDirectory, "Output directory must be initialized.");
+    DocumentBuilderFactory docFactory = DocumentBuilderFactory.newInstance();
+    try {
+      // Create file.
+      Files.createFile(path);
+
+      DocumentBuilder docBuilder = docFactory.newDocumentBuilder();
+      Document doc = docBuilder.newDocument();
+
+      // Root
+      Element rootElement = doc.createElement("scanner");
+      doc.appendChild(rootElement);
+
+      // Method
+      Element methodElement = doc.createElement("method");
+      methodElement.setAttribute("active", String.valueOf(methodTrackerIsActive));
+      rootElement.appendChild(methodElement);
+
+      // Field
+      Element fieldElement = doc.createElement("field");
+      fieldElement.setAttribute("active", String.valueOf(fieldTrackerIsActive));
+      rootElement.appendChild(fieldElement);
+
+      // Call
+      Element callElement = doc.createElement("call");
+      callElement.setAttribute("active", String.valueOf(callTrackerIsActive));
+      rootElement.appendChild(callElement);
+
+      // File
+      Element classElement = doc.createElement("class");
+      classElement.setAttribute("active", String.valueOf(classTrackerIsActive));
+      rootElement.appendChild(classElement);
+
+      // UUID
+      Element uuid = doc.createElement("uuid");
+      uuid.setTextContent(UUID.randomUUID().toString());
+      rootElement.appendChild(uuid);
+
+      // Output dir
+      Element outputDir = doc.createElement("path");
+      outputDir.setTextContent(this.outputDirectory.toString());
+      rootElement.appendChild(outputDir);
+
+      // Writings
+      TransformerFactory transformerFactory = TransformerFactory.newInstance();
+      Transformer transformer = transformerFactory.newTransformer();
+      DOMSource source = new DOMSource(doc);
+      StreamResult result = new StreamResult(path.toFile());
+      transformer.transform(source, result);
+    } catch (ParserConfigurationException | TransformerException | IOException e) {
+      throw new RuntimeException("Error happened in writing config.", e);
+    }
+  }
+}

--- a/annotator-scanner/src/main/java/edu/ucr/cs/riple/scanner/ScannerConfigWriter.java
+++ b/annotator-scanner/src/main/java/edu/ucr/cs/riple/scanner/ScannerConfigWriter.java
@@ -95,7 +95,9 @@ public class ScannerConfigWriter {
     Preconditions.checkNotNull(this.outputDirectory, "Output directory must be initialized.");
     DocumentBuilderFactory docFactory = DocumentBuilderFactory.newInstance();
     try {
-      // Create file.
+      // Delete if exists.
+      Files.deleteIfExists(path);
+      // Re-Create file.
       Files.createFile(path);
 
       DocumentBuilder docBuilder = docFactory.newDocumentBuilder();

--- a/annotator-scanner/src/test/java/edu/ucr/cs/riple/scanner/AnnotatorScannerBaseTest.java
+++ b/annotator-scanner/src/test/java/edu/ucr/cs/riple/scanner/AnnotatorScannerBaseTest.java
@@ -56,18 +56,17 @@ public abstract class AnnotatorScannerBaseTest<T extends Display> {
   @Before
   public void setup() {
     root = Paths.get(temporaryFolder.getRoot().getAbsolutePath());
-    Path config = root.resolve("scanner.xml");
+    Path configPath = root.resolve("scanner.xml");
     try {
       Files.createDirectories(root);
-      ErrorProneCLIFlagsConfig.Builder builder =
-          new ErrorProneCLIFlagsConfig.Builder()
-              .setCallTrackerActivation(true)
-              .setClassTrackerActivation(true)
-              .setFieldTrackerActivation(true)
-              .setMethodTrackerActivation(true)
-              .setOutput(root);
-      Files.createFile(config);
-      builder.writeAsXML(config);
+      ScannerConfigWriter writer = new ScannerConfigWriter();
+      writer
+          .setCallTrackerActivation(true)
+          .setClassTrackerActivation(true)
+          .setFieldTrackerActivation(true)
+          .setMethodTrackerActivation(true)
+          .setOutput(root)
+          .writeAsXML(configPath);
     } catch (IOException ex) {
       throw new UncheckedIOException(ex);
     }
@@ -78,7 +77,7 @@ public abstract class AnnotatorScannerBaseTest<T extends Display> {
                     "-d",
                     temporaryFolder.getRoot().getAbsolutePath(),
                     "-Xep:AnnotatorScanner:ERROR",
-                    "-XepOpt:AnnotatorScanner:ConfigPath=" + config))
+                    "-XepOpt:AnnotatorScanner:ConfigPath=" + configPath))
             .setOutputFileNameAndHeader(fileName, header)
             .setFactory(factory);
   }


### PR DESCRIPTION
This PR simply extracts the config writer inside the `annotator-scanner` module into a separate standalone class, and reuses it in `annotator-core` module.

Please note that this is a preparation for the upcoming PR handling region selection for generated code. 