### PR TITLE
Update tracker node construction

### DIFF
--- a/annotator-core/src/main/java/edu/ucr/cs/riple/core/adapters/NullAwayV0Adapter.java
+++ b/annotator-core/src/main/java/edu/ucr/cs/riple/core/adapters/NullAwayV0Adapter.java
@@ -90,8 +90,9 @@ public class NullAwayV0Adapter implements NullAwayVersionAdapter {
         values.length == 4,
         "Expected 4 values to create TrackerNode instance in NullAway serialization version 0 but found: "
             + values.length);
-    String encMember = !Region.getType(values[1]).equals(Region.Type.METHOD) ? "null" : values[1];
-    return new TrackerNode(values[0], encMember, values[2], values[3]);
+    String regionMember =
+        !Region.getType(values[1]).equals(Region.Type.METHOD) ? "null" : values[1];
+    return new TrackerNode(new Region(values[0], regionMember), values[2], values[3]);
   }
 
   @Override

--- a/annotator-core/src/main/java/edu/ucr/cs/riple/core/adapters/NullAwayV1Adapter.java
+++ b/annotator-core/src/main/java/edu/ucr/cs/riple/core/adapters/NullAwayV1Adapter.java
@@ -88,7 +88,7 @@ public class NullAwayV1Adapter implements NullAwayVersionAdapter {
         values.length == 4,
         "Expected 4 values to create TrackerNode instance in NullAway serialization version 1 but found: "
             + values.length);
-    return new TrackerNode(values[0], values[1], values[2], values[3]);
+    return new TrackerNode(new Region(values[0], values[1]), values[2], values[3]);
   }
 
   @Override

--- a/annotator-core/src/main/java/edu/ucr/cs/riple/core/metadata/trackers/FieldRegionTracker.java
+++ b/annotator-core/src/main/java/edu/ucr/cs/riple/core/metadata/trackers/FieldRegionTracker.java
@@ -68,7 +68,7 @@ public class FieldRegionTracker extends MetaData<TrackerNode> implements RegionT
                     candidate.calleeClass.equals(field.clazz)
                         && field.isOnFieldWithName(candidate.calleeMember),
                 TrackerNode.hash(field.clazz))
-            .map(trackerNode -> new Region(trackerNode.callerClass, trackerNode.callerMember))
+            .map(trackerNode -> trackerNode.region)
             .collect(Collectors.toSet());
     ans.addAll(config.getAdapter().getFieldRegionScope(field));
     return Optional.of(ans);

--- a/annotator-core/src/main/java/edu/ucr/cs/riple/core/metadata/trackers/MethodRegionTracker.java
+++ b/annotator-core/src/main/java/edu/ucr/cs/riple/core/metadata/trackers/MethodRegionTracker.java
@@ -94,7 +94,7 @@ public class MethodRegionTracker extends MetaData<TrackerNode> implements Region
             candidate ->
                 candidate.calleeClass.equals(clazz) && candidate.calleeMember.equals(method),
             TrackerNode.hash(clazz))
-        .map(node -> new Region(node.callerClass, node.callerMember))
+        .map(node -> node.region)
         .collect(Collectors.toSet());
   }
 }

--- a/annotator-core/src/main/java/edu/ucr/cs/riple/core/metadata/trackers/TrackerNode.java
+++ b/annotator-core/src/main/java/edu/ucr/cs/riple/core/metadata/trackers/TrackerNode.java
@@ -30,19 +30,15 @@ import java.util.Objects;
 /** Container class for holding information regarding usage of class members within classes. */
 public class TrackerNode implements Hashable {
 
-  /** Fully qualified names of the caller class. */
-  public final String callerClass;
-  /** Symbol the target region. */
-  public final String callerMember;
-  /** Callee field name if field and method signature if method. */
+  /** Region where the element is used. */
+  public final Region region;
+
   public final String calleeMember;
   /** Fully qualified name of the enclosing class of callee. */
   public final String calleeClass;
 
-  public TrackerNode(
-      String callerClass, String callerMember, String calleeMember, String calleeClass) {
-    this.callerClass = callerClass;
-    this.callerMember = callerMember;
+  public TrackerNode(Region region, String calleeMember, String calleeClass) {
+    this.region = region;
     this.calleeMember = calleeMember;
     this.calleeClass = calleeClass;
   }
@@ -56,10 +52,9 @@ public class TrackerNode implements Hashable {
       return false;
     }
     TrackerNode that = (TrackerNode) o;
-    return callerClass.equals(that.callerClass)
+    return region.equals(that.region)
         && calleeMember.equals(that.calleeMember)
-        && calleeClass.equals(that.calleeClass)
-        && callerMember.equals(that.callerMember);
+        && calleeClass.equals(that.calleeClass);
   }
 
   /**


### PR DESCRIPTION
This PR updates tracker nodes to receive a region as a parameter instead of raw region class name and region member. 

Please note that this is a preparation for the upcoming PR handling region selection for generated code.