### PR TITLE
Remove unused "duplicate" API on Location instances

### DIFF
--- a/injector/src/main/java/edu/ucr/cs/riple/injector/changes/AddMarkerAnnotation.java
+++ b/injector/src/main/java/edu/ucr/cs/riple/injector/changes/AddMarkerAnnotation.java
@@ -57,9 +57,4 @@ public class AddMarkerAnnotation extends AddAnnotation {
     }
     return new Insertion(annotationExpr.toString(), range.begin);
   }
-
-  @Override
-  public Change duplicate() {
-    return new AddMarkerAnnotation(location, annotation);
-  }
 }

--- a/injector/src/main/java/edu/ucr/cs/riple/injector/changes/AddSingleElementAnnotation.java
+++ b/injector/src/main/java/edu/ucr/cs/riple/injector/changes/AddSingleElementAnnotation.java
@@ -139,11 +139,6 @@ public class AddSingleElementAnnotation extends AddAnnotation {
         singleMemberAnnotationExpr.toString(), annotRange.get().begin, annotRange.get().end);
   }
 
-  @Override
-  public Change duplicate() {
-    return new AddSingleElementAnnotation(location.duplicate(), annotation, argument, repeatable);
-  }
-
   /**
    * Translates addition of an {@link AnnotationExpr} to a {@link NodeWithAnnotations} instance with
    * the given name and arguments.

--- a/injector/src/main/java/edu/ucr/cs/riple/injector/changes/Change.java
+++ b/injector/src/main/java/edu/ucr/cs/riple/injector/changes/Change.java
@@ -94,8 +94,6 @@ public abstract class Change {
     return res;
   }
 
-  public abstract Change duplicate();
-
   @Override
   public String toString() {
     return location.toString();

--- a/injector/src/main/java/edu/ucr/cs/riple/injector/changes/RemoveAnnotation.java
+++ b/injector/src/main/java/edu/ucr/cs/riple/injector/changes/RemoveAnnotation.java
@@ -71,11 +71,6 @@ public class RemoveAnnotation extends Change {
   }
 
   @Override
-  public Change duplicate() {
-    return new RemoveAnnotation(location.duplicate(), annotation);
-  }
-
-  @Override
   public boolean equals(Object other) {
     boolean superAns = super.equals(other);
     if (!superAns) {

--- a/injector/src/main/java/edu/ucr/cs/riple/injector/location/Location.java
+++ b/injector/src/main/java/edu/ucr/cs/riple/injector/location/Location.java
@@ -104,8 +104,6 @@ public abstract class Location {
     throw new RuntimeException("Cannot reach this statement, values: " + Arrays.toString(values));
   }
 
-  public abstract Location duplicate();
-
   protected abstract Modification applyToMember(NodeList<BodyDeclaration<?>> clazz, Change change);
 
   protected abstract void fillJsonInformation(JSONObject res);

--- a/injector/src/main/java/edu/ucr/cs/riple/injector/location/OnField.java
+++ b/injector/src/main/java/edu/ucr/cs/riple/injector/location/OnField.java
@@ -31,7 +31,6 @@ import com.github.javaparser.ast.body.VariableDeclarator;
 import edu.ucr.cs.riple.injector.changes.Change;
 import edu.ucr.cs.riple.injector.modifications.Modification;
 import java.util.Collections;
-import java.util.HashSet;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
@@ -58,11 +57,6 @@ public class OnField extends Location {
   public OnField(String uri, String clazz, Set<String> variables) {
     super(LocationType.FIELD, uri, clazz);
     this.variables = variables;
-  }
-
-  @Override
-  public Location duplicate() {
-    return new OnField(uri, clazz, new HashSet<>(variables));
   }
 
   @SuppressWarnings("unchecked")

--- a/injector/src/main/java/edu/ucr/cs/riple/injector/location/OnMethod.java
+++ b/injector/src/main/java/edu/ucr/cs/riple/injector/location/OnMethod.java
@@ -47,11 +47,6 @@ public class OnMethod extends Location {
     this.matcher = new SignatureMatcher(method);
   }
 
-  @Override
-  public Location duplicate() {
-    return new OnMethod(uri, clazz, method);
-  }
-
   @SuppressWarnings("unchecked")
   @Override
   protected void fillJsonInformation(JSONObject res) {

--- a/injector/src/main/java/edu/ucr/cs/riple/injector/location/OnParameter.java
+++ b/injector/src/main/java/edu/ucr/cs/riple/injector/location/OnParameter.java
@@ -51,11 +51,6 @@ public class OnParameter extends Location {
     this.matcher = new SignatureMatcher(method);
   }
 
-  @Override
-  public Location duplicate() {
-    return new OnParameter(uri, clazz, method, index);
-  }
-
   @SuppressWarnings("unchecked")
   @Override
   protected void fillJsonInformation(JSONObject res) {

--- a/injector/src/test/java/edu/ucr/cs/riple/injector/BasicTest.java
+++ b/injector/src/test/java/edu/ucr/cs/riple/injector/BasicTest.java
@@ -36,9 +36,16 @@ public class BasicTest extends BaseInjectorTest {
 
   @Test
   public void skip_duplicate_annotation() {
-    Change Change =
+    Change change1 =
         new AddMarkerAnnotation(
             new OnMethod("Super.java", "com.uber.Super", "test()"), "javax.annotation.Nullable");
+    Change change2 =
+        new AddMarkerAnnotation(
+            new OnMethod("Super.java", "com.uber.Super", "test()"), "javax.annotation.Nullable");
+    Change change3 =
+        new AddMarkerAnnotation(
+            new OnMethod("Super.java", "com.uber.Super", "test()"), "javax.annotation.Nullable");
+
     injectorTestHelper
         .addInput(
             "Super.java",
@@ -57,7 +64,7 @@ public class BasicTest extends BaseInjectorTest {
             "       return new Object();",
             "   }",
             "}")
-        .addChanges(Change, Change.duplicate(), Change.duplicate())
+        .addChanges(change1, change2, change2)
         .start();
   }
 


### PR DESCRIPTION
This PR removes `duplicate` method on `Location` instances which is unused in the source code and only used in one unit tests. 

This PR is straightforward and simply removes an used method, I am going to land this PR once CI passes, if there is anything you would like to discuss, please let me know and I will bring this back.

Please note, that this was required for #121 which resolves flaky CI issue.