### PR TITLE
Resolve #128 by including null regions

### DIFF
--- a/annotator-core/src/main/java/edu/ucr/cs/riple/core/adapters/NullAwayV0Adapter.java
+++ b/annotator-core/src/main/java/edu/ucr/cs/riple/core/adapters/NullAwayV0Adapter.java
@@ -70,11 +70,13 @@ public class NullAwayV0Adapter extends NullAwayAdapterBaseClass {
             + values.length);
     Preconditions.checkArgument(
         values[7].equals("nullable"), "unsupported annotation: " + values[7]);
-    String encMember = !Region.getType(values[9]).equals(Region.Type.METHOD) ? "null" : values[9];
+    String regionClass = values[8];
+    String encMember =
+        !Region.getType(regionClass, values[9]).equals(Region.Type.METHOD) ? "null" : values[9];
     return new Fix(
         new AddMarkerAnnotation(location, config.nullableAnnot),
         values[6],
-        new Region(values[8], encMember),
+        new Region(regionClass, encMember),
         true);
   }
 
@@ -84,12 +86,14 @@ public class NullAwayV0Adapter extends NullAwayAdapterBaseClass {
         values.length == 10,
         "Expected 10 values to create Error instance in NullAway serialization version 0 but found: "
             + values.length);
-    String encMember = !Region.getType(values[3]).equals(Region.Type.METHOD) ? "null" : values[3];
+    String regionClass = values[2];
+    String encMember =
+        !Region.getType(regionClass, values[3]).equals(Region.Type.METHOD) ? "null" : values[3];
     Location nonnullTarget =
         Location.createLocationFromArrayInfo(Arrays.copyOfRange(values, 4, 10));
     String errorType = values[0];
     String errorMessage = values[1];
-    Region region = new Region(values[2], encMember);
+    Region region = new Region(regionClass, encMember);
     // since we have no information of offset, we give a unique offset error to have different
     // instances.
     return createError(
@@ -102,10 +106,11 @@ public class NullAwayV0Adapter extends NullAwayAdapterBaseClass {
         values.length == 5,
         "Expected 5 values to create TrackerNode instance in NullAway serialization version 0 but found: "
             + values.length);
+    String regionClass = values[0];
     String regionMember =
-        !Region.getType(values[1]).equals(Region.Type.METHOD) ? "null" : values[1];
+        !Region.getType(regionClass, values[1]).equals(Region.Type.METHOD) ? "null" : values[1];
     return new TrackerNode(
-        new Region(values[0], regionMember, SourceType.valueOf(values[4])), values[2], values[3]);
+        new Region(regionClass, regionMember, SourceType.valueOf(values[4])), values[2], values[3]);
   }
 
   @Override

--- a/annotator-core/src/main/java/edu/ucr/cs/riple/core/metadata/index/Bank.java
+++ b/annotator-core/src/main/java/edu/ucr/cs/riple/core/metadata/index/Bank.java
@@ -28,6 +28,7 @@ import com.google.common.base.Preconditions;
 import com.google.common.collect.ImmutableSet;
 import edu.ucr.cs.riple.core.metadata.trackers.Region;
 import java.nio.file.Path;
+import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Set;
 import java.util.function.Predicate;
@@ -93,8 +94,9 @@ public class Bank<T extends Enclosed> {
    */
   private Result<T> compareByList(Collection<T> previousItems, Collection<T> currentItems) {
     int size = currentItems.size() - previousItems.size();
-    previousItems.forEach(currentItems::remove);
-    return new Result<>(size, currentItems);
+    ArrayList<T> temp = new ArrayList<>(currentItems);
+    previousItems.forEach(temp::remove);
+    return new Result<>(size, temp);
   }
 
   /**

--- a/annotator-core/src/main/java/edu/ucr/cs/riple/core/metadata/trackers/Region.java
+++ b/annotator-core/src/main/java/edu/ucr/cs/riple/core/metadata/trackers/Region.java
@@ -24,6 +24,7 @@
 
 package edu.ucr.cs.riple.core.metadata.trackers;
 
+import edu.ucr.cs.riple.injector.Helper;
 import edu.ucr.cs.riple.scanner.generatedcode.SourceType;
 import java.util.Objects;
 
@@ -50,6 +51,7 @@ public class Region {
   /** Different types of code segments for a region. */
   public enum Type {
     METHOD,
+    CONSTRUCTOR,
     FIELD,
     STATIC_BLOCK
   }
@@ -57,7 +59,7 @@ public class Region {
   public Region(String encClass, String encMember, SourceType sourceType) {
     this.clazz = encClass == null ? "null" : encClass;
     this.member = encMember == null ? "null" : encMember;
-    this.type = getType(member);
+    this.type = getType(clazz, member);
     this.sourceType = sourceType;
   }
 
@@ -68,14 +70,18 @@ public class Region {
   /**
    * Initializes {@link Region#type} based on the string representation of member.
    *
-   * @param member Symbol of the region representative.
+   * @param regionClass Symbol of the region class in string.
+   * @param member Symbol of the region representative in string.
    * @return The corresponding Type.
    */
-  public static Type getType(String member) {
+  public static Type getType(String regionClass, String member) {
     if (member.equals("null")) {
       return Type.STATIC_BLOCK;
     }
     if (member.contains("(")) {
+      if (Helper.extractCallableName(member).equals(Helper.simpleName(regionClass))) {
+        return Type.CONSTRUCTOR;
+      }
       return Type.METHOD;
     }
     return Type.FIELD;
@@ -97,6 +103,15 @@ public class Region {
    */
   public boolean isOnField() {
     return type.equals(Type.FIELD);
+  }
+
+  /**
+   * Checks if region targets a constructor.
+   *
+   * @return true, if region is targeting a constructor.
+   */
+  public boolean isOnConstructor() {
+    return type.equals(Type.CONSTRUCTOR);
   }
 
   @Override

--- a/annotator-core/src/test/java/edu/ucr/cs/riple/core/DownstreamAnalysisTest.java
+++ b/annotator-core/src/test/java/edu/ucr/cs/riple/core/DownstreamAnalysisTest.java
@@ -40,8 +40,8 @@ public class DownstreamAnalysisTest extends BaseCoreTest {
     coreTestHelper
         .addExpectedReports(
             // Change reduces errors on target by -4, but increases them in downstream dependency
-            // DepA by 3, DepB by 4 and DepC by 2. Hence, the total effect is: 5.
-            new TReport(new OnMethod("Foo.java", "test.target.Foo", "returnNullableBad(int)"), 5),
+            // DepA by 3, DepB by 4 and DepC by 3. Hence, the total effect is: 5.
+            new TReport(new OnMethod("Foo.java", "test.target.Foo", "returnNullableBad(int)"), 6),
             // Change reduces errors on target by -5, but increases them in downstream dependency
             // DepA by 0, DepB by 1 and DepC by 0. Hence, the total effect is: -4.
             new TReport(new OnMethod("Foo.java", "test.target.Foo", "returnNullableGood(int)"), -4),
@@ -78,13 +78,14 @@ public class DownstreamAnalysisTest extends BaseCoreTest {
   public void lowerBoundComputationTest() {
     coreTestHelper
         .addExpectedReports(
-            // Only returnNullableBad triggers new errors in this fix chain (+9), lower bound is 9.
-            new TReport(new OnMethod("Foo.java", "test.target.Foo", "returnNullableBad(int)"), 9),
+            // Only returnNullableBad triggers new errors in this fix chain (+10), lower bound is
+            // 10.
+            new TReport(new OnMethod("Foo.java", "test.target.Foo", "returnNullableBad(int)"), 10),
             // Only returnNullableGood triggers new errors in this fix chain (+1), lower bound is 1.
             new TReport(new OnMethod("Foo.java", "test.target.Foo", "returnNullableGood(int)"), 1),
             // Root fix triggers 1 error on downstream dependency but returnNullableBad is
-            // present in the fix tree, therefore the lower bound effect for the tree should be 9.
-            new TReport(new OnMethod("Foo.java", "test.target.Foo", "bar()"), 9))
+            // present in the fix tree, therefore the lower bound effect for the tree should be 10.
+            new TReport(new OnMethod("Foo.java", "test.target.Foo", "bar()"), 10))
         .setPredicate(
             (expected, found) ->
                 expected.root.equals(found.root)
@@ -100,16 +101,17 @@ public class DownstreamAnalysisTest extends BaseCoreTest {
   public void upperBoundComputationTest() {
     coreTestHelper
         .addExpectedReports(
-            // Only returnNullableBad triggers new errors in this fix chain (+9) and upper bound
-            // should be 9
-            new TReport(new OnMethod("Foo.java", "test.target.Foo", "returnNullableBad(int)"), 9),
+            // Only returnNullableBad triggers new errors in this fix chain (+10) and upper bound
+            // should be 10
+            new TReport(new OnMethod("Foo.java", "test.target.Foo", "returnNullableBad(int)"), 10),
             // Only returnNullableGood triggers new errors in this fix chain (+1) and upper bound
             // should be 1
             new TReport(new OnMethod("Foo.java", "test.target.Foo", "returnNullableGood(int)"), 1),
             // Root fix triggers 1 error on downstream dependency and returnNullableBad is
-            // present in the fix tree and triggers 9 errors on downstream dependency, therefore the
-            // upper bound effect for the tree should be 10.
-            new TReport(new OnMethod("Foo.java", "test.target.Foo", "bar()"), 10))
+            // present in the fix tree and triggers 10 errors on downstream dependency, therefore
+            // the
+            // upper bound effect for the tree should be 11.
+            new TReport(new OnMethod("Foo.java", "test.target.Foo", "bar()"), 11))
         .setPredicate(
             (expected, found) ->
                 expected.root.equals(found.root)

--- a/annotator-core/src/test/java/edu/ucr/cs/riple/core/tools/CoreTestHelper.java
+++ b/annotator-core/src/test/java/edu/ucr/cs/riple/core/tools/CoreTestHelper.java
@@ -279,7 +279,7 @@ public class CoreTestHelper {
     builder.bailout = !disableBailout;
     builder.chain = true;
     builder.outerLoopActivation = requestCompleteLoop;
-    builder.optimized = true;
+    builder.optimized = false;
     builder.downStreamDependenciesAnalysisActivated = downstreamDependencyAnalysisActivated;
     builder.mode = mode;
     builder.inferenceActivated = !deactivateInference;


### PR DESCRIPTION
This PR resolves #128 by including `null` regions in potentially impacted regions for methods that are called within constructors.