### PR TITLE
Rename to triggeredFixesOnDownstream to triggeredFixesFromDownstream

### DIFF
--- a/annotator-core/src/main/java/edu/ucr/cs/riple/core/AnalysisMode.java
+++ b/annotator-core/src/main/java/edu/ucr/cs/riple/core/AnalysisMode.java
@@ -28,7 +28,7 @@ import static edu.ucr.cs.riple.core.Report.Tag.APPROVE;
 import static edu.ucr.cs.riple.core.Report.Tag.REJECT;
 
 import com.google.common.base.Preconditions;
-import edu.ucr.cs.riple.core.global.GlobalAnalyzer;
+import edu.ucr.cs.riple.core.global.DownstreamImpactCache;
 import java.util.Collection;
 
 /** Analysis mode in making inference decisions. */
@@ -39,7 +39,7 @@ public enum AnalysisMode {
    */
   LOCAL {
     @Override
-    public void tag(Config config, GlobalAnalyzer analyzer, Collection<Report> reports) {
+    public void tag(Config config, DownstreamImpactCache analyzer, Collection<Report> reports) {
       reports.forEach(
           report -> {
             if (report.localEffect < 1) {
@@ -57,7 +57,7 @@ public enum AnalysisMode {
    */
   STRICT {
     @Override
-    public void tag(Config config, GlobalAnalyzer analyzer, Collection<Report> reports) {
+    public void tag(Config config, DownstreamImpactCache analyzer, Collection<Report> reports) {
       reports.forEach(
           report -> {
             // Check for destructive methods.
@@ -83,7 +83,7 @@ public enum AnalysisMode {
    */
   UPPER_BOUND {
     @Override
-    public void tag(Config config, GlobalAnalyzer analyzer, Collection<Report> reports) {
+    public void tag(Config config, DownstreamImpactCache analyzer, Collection<Report> reports) {
       reports.forEach(
           report -> {
             if (report.localEffect + report.getUpperBoundEffectOnDownstreamDependencies() < 1) {
@@ -101,7 +101,7 @@ public enum AnalysisMode {
    */
   LOWER_BOUND {
     @Override
-    public void tag(Config config, GlobalAnalyzer analyzer, Collection<Report> reports) {
+    public void tag(Config config, DownstreamImpactCache analyzer, Collection<Report> reports) {
       reports.forEach(
           report -> {
             if (report.localEffect + report.getLowerBoundEffectOnDownstreamDependencies() < 1) {
@@ -120,7 +120,8 @@ public enum AnalysisMode {
    * @param analyzer Downstream dependency instance.
    * @param reports Reports to be processed.
    */
-  public abstract void tag(Config config, GlobalAnalyzer analyzer, Collection<Report> reports);
+  public abstract void tag(
+      Config config, DownstreamImpactCache analyzer, Collection<Report> reports);
 
   /**
    * Parses the received option and returns the corresponding {@link AnalysisMode}. Can only be one

--- a/annotator-core/src/main/java/edu/ucr/cs/riple/core/Annotator.java
+++ b/annotator-core/src/main/java/edu/ucr/cs/riple/core/Annotator.java
@@ -29,9 +29,9 @@ import edu.ucr.cs.riple.core.evaluators.BasicEvaluator;
 import edu.ucr.cs.riple.core.evaluators.Evaluator;
 import edu.ucr.cs.riple.core.evaluators.VoidEvaluator;
 import edu.ucr.cs.riple.core.evaluators.suppliers.TargetModuleSupplier;
-import edu.ucr.cs.riple.core.global.GlobalAnalyzer;
-import edu.ucr.cs.riple.core.global.GlobalAnalyzerImpl;
-import edu.ucr.cs.riple.core.global.NoOpGlobalAnalyzer;
+import edu.ucr.cs.riple.core.global.DownstreamImpactCache;
+import edu.ucr.cs.riple.core.global.DownstreamImpactCacheImpl;
+import edu.ucr.cs.riple.core.global.VoidDownstreamImpactCache;
 import edu.ucr.cs.riple.core.injectors.AnnotationInjector;
 import edu.ucr.cs.riple.core.injectors.PhysicalInjector;
 import edu.ucr.cs.riple.core.metadata.field.FieldDeclarationStore;
@@ -116,21 +116,21 @@ public class Annotator {
 
   /** Performs iterations of inference/injection until no unseen fix is suggested. */
   private void annotate() {
-    // globalAnalyzer analyzes effects of all public APIs on downstream dependencies.
+    // downstreamImpactCache analyzes effects of all public APIs on downstream dependencies.
     // Through iterations, since the source code for downstream dependencies does not change and the
     // computation does not depend on the changes in the target module, it will compute the same
     // result in each iteration, therefore we perform the analysis only once and reuse it in each
     // iteration.
-    GlobalAnalyzer globalAnalyzer =
+    DownstreamImpactCache downstreamImpactCache =
         config.downStreamDependenciesAnalysisActivated
-            ? new GlobalAnalyzerImpl(config, methodDeclarationTree)
-            : new NoOpGlobalAnalyzer();
-    globalAnalyzer.analyzeDownstreamDependencies();
+            ? new DownstreamImpactCacheImpl(config, methodDeclarationTree)
+            : new VoidDownstreamImpactCache();
+    downstreamImpactCache.analyzeDownstreamDependencies();
 
     if (config.inferenceActivated) {
       // Outer loop starts.
       while (cache.isUpdated()) {
-        executeNextIteration(globalAnalyzer);
+        executeNextIteration(downstreamImpactCache);
         if (config.disableOuterLoop) {
           break;
         }
@@ -139,7 +139,7 @@ public class Annotator {
       // Perform once last iteration including all fixes.
       if (!config.disableOuterLoop) {
         cache.disable();
-        executeNextIteration(globalAnalyzer);
+        executeNextIteration(downstreamImpactCache);
         cache.enable();
       }
     }
@@ -155,23 +155,23 @@ public class Annotator {
   /**
    * Performs single iteration of inference/injection.
    *
-   * @param globalAnalyzer Global analyzer instance to detect impact of fixes outside of target
-   *     module.
+   * @param downstreamImpactCache Global analyzer instance to detect impact of fixes outside of
+   *     target module.
    */
-  private void executeNextIteration(GlobalAnalyzer globalAnalyzer) {
-    ImmutableSet<Report> latestReports = processTriggeredFixes(globalAnalyzer);
+  private void executeNextIteration(DownstreamImpactCache downstreamImpactCache) {
+    ImmutableSet<Report> latestReports = processTriggeredFixes(downstreamImpactCache);
     // Compute boundaries of effects on downstream dependencies.
     latestReports.forEach(
         report -> {
           if (config.downStreamDependenciesAnalysisActivated) {
-            report.computeBoundariesOfEffectivenessOnDownstreamDependencies(globalAnalyzer);
+            report.computeBoundariesOfEffectivenessOnDownstreamDependencies(downstreamImpactCache);
           }
         });
     // Update cached reports store.
     cache.update(latestReports);
 
     // Tag reports according to selected analysis mode.
-    config.mode.tag(config, globalAnalyzer, latestReports);
+    config.mode.tag(config, downstreamImpactCache, latestReports);
 
     // Inject approved fixes.
     Set<Fix> selectedFixes =
@@ -186,16 +186,16 @@ public class Annotator {
         selectedFixes.stream().map(fix -> fix.change).collect(Collectors.toSet()));
 
     // Update impact saved state.
-    globalAnalyzer.updateImpactsAfterInjection(selectedFixes);
+    downstreamImpactCache.updateImpactsAfterInjection(selectedFixes);
   }
 
   /**
    * Processes triggered fixes.
    *
-   * @param globalAnalyzer Global Analyzer instance.
+   * @param downstreamImpactCache Global Analyzer instance.
    * @return Immutable set of reports from the triggered fixes.
    */
-  private ImmutableSet<Report> processTriggeredFixes(GlobalAnalyzer globalAnalyzer) {
+  private ImmutableSet<Report> processTriggeredFixes(DownstreamImpactCache downstreamImpactCache) {
     Utility.buildTarget(config);
     // Suggested fixes of target at the current state.
     ImmutableSet<Fix> fixes =
@@ -205,7 +205,7 @@ public class Annotator {
 
     // Initializing required evaluator instances.
     TargetModuleSupplier supplier =
-        new TargetModuleSupplier(config, globalAnalyzer, methodDeclarationTree);
+        new TargetModuleSupplier(config, downstreamImpactCache, methodDeclarationTree);
     Evaluator evaluator =
         config.exhaustiveSearch ? new VoidEvaluator() : new BasicEvaluator(supplier);
     // Result of the iteration analysis.

--- a/annotator-core/src/main/java/edu/ucr/cs/riple/core/Report.java
+++ b/annotator-core/src/main/java/edu/ucr/cs/riple/core/Report.java
@@ -26,7 +26,7 @@ package edu.ucr.cs.riple.core;
 
 import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Sets;
-import edu.ucr.cs.riple.core.global.GlobalAnalyzer;
+import edu.ucr.cs.riple.core.global.DownstreamImpactCache;
 import edu.ucr.cs.riple.core.metadata.index.Error;
 import edu.ucr.cs.riple.core.metadata.index.Fix;
 import edu.ucr.cs.riple.injector.location.Location;
@@ -100,7 +100,7 @@ public class Report {
    * @return true, if report contains a fix which will trigger an unresolvable error in downstream
    *     dependency.
    */
-  public boolean containsDestructiveMethod(GlobalAnalyzer analyzer) {
+  public boolean containsDestructiveMethod(DownstreamImpactCache analyzer) {
     return this.tree.stream().anyMatch(analyzer::isNotFixableOnTarget);
   }
 
@@ -202,7 +202,8 @@ public class Report {
    *
    * @param analyzer Downstream dependency analyzer instance.
    */
-  public void computeBoundariesOfEffectivenessOnDownstreamDependencies(GlobalAnalyzer analyzer) {
+  public void computeBoundariesOfEffectivenessOnDownstreamDependencies(
+      DownstreamImpactCache analyzer) {
     this.lowerBoundEffectOnDownstreamDependencies =
         analyzer.computeLowerBoundOfNumberOfErrors(tree);
     this.upperBoundEffectOnDownstreamDependencies =

--- a/annotator-core/src/main/java/edu/ucr/cs/riple/core/Report.java
+++ b/annotator-core/src/main/java/edu/ucr/cs/riple/core/Report.java
@@ -257,7 +257,8 @@ public class Report {
       // report has not been processed.
       return true;
     }
-    if (triggeredFixesFromDownstream.size() != 0 && !tree.containsAll(triggeredFixesFromDownstream)) {
+    if (triggeredFixesFromDownstream.size() != 0
+        && !tree.containsAll(triggeredFixesFromDownstream)) {
       // Report contains fixes from downstream dependencies, their effectiveness on target module
       // should be investigated.
       return true;

--- a/annotator-core/src/main/java/edu/ucr/cs/riple/core/Report.java
+++ b/annotator-core/src/main/java/edu/ucr/cs/riple/core/Report.java
@@ -55,7 +55,7 @@ public class Report {
    * Set of triggered fixes on target module that will be triggered if fix tree is applied due to
    * errors in downstream dependencies.
    */
-  public ImmutableSet<Fix> triggeredFixesOnDownstream;
+  public ImmutableSet<Fix> triggeredFixesFromDownstream;
   /** If true, this report's tree has been processed for at least one iteration */
   public boolean hasBeenProcessedOnce;
   /**
@@ -85,7 +85,7 @@ public class Report {
     this.root = root;
     this.tree = Sets.newHashSet(root);
     this.hasBeenProcessedOnce = false;
-    this.triggeredFixesOnDownstream = ImmutableSet.of();
+    this.triggeredFixesFromDownstream = ImmutableSet.of();
     this.triggeredErrors = ImmutableSet.of();
     this.lowerBoundEffectOnDownstreamDependencies = 0;
     this.upperBoundEffectOnDownstreamDependencies = 0;
@@ -257,7 +257,7 @@ public class Report {
       // report has not been processed.
       return true;
     }
-    if (triggeredFixesOnDownstream.size() != 0 && !tree.containsAll(triggeredFixesOnDownstream)) {
+    if (triggeredFixesFromDownstream.size() != 0 && !tree.containsAll(triggeredFixesFromDownstream)) {
       // Report contains fixes from downstream dependencies, their effectiveness on target module
       // should be investigated.
       return true;

--- a/annotator-core/src/main/java/edu/ucr/cs/riple/core/evaluators/BasicEvaluator.java
+++ b/annotator-core/src/main/java/edu/ucr/cs/riple/core/evaluators/BasicEvaluator.java
@@ -49,8 +49,8 @@ public class BasicEvaluator extends AbstractEvaluator {
               Node node = graph.addNodeToVertices(root);
               node.setOrigins(supplier.getErrorStore());
               node.report = report;
-              node.triggeredFixesOnDownstream =
-                  ImmutableSet.copyOf(report.triggeredFixesOnDownstream);
+              node.triggeredFixesFromDownstream =
+                  ImmutableSet.copyOf(report.triggeredFixesFromDownstream);
               node.tree.addAll(Sets.newHashSet(report.tree));
               node.triggeredErrors = ImmutableSet.copyOf(report.triggeredErrors);
               node.mergeTriggered();
@@ -66,8 +66,8 @@ public class BasicEvaluator extends AbstractEvaluator {
               Report report = node.report;
               report.localEffect = node.effect;
               report.tree = Sets.newHashSet(node.tree);
-              report.triggeredFixesOnDownstream =
-                  ImmutableSet.copyOf(node.triggeredFixesOnDownstream);
+              report.triggeredFixesFromDownstream =
+                  ImmutableSet.copyOf(node.triggeredFixesFromDownstream);
               report.triggeredErrors = ImmutableSet.copyOf(node.triggeredErrors);
               report.hasBeenProcessedOnce = true;
             });

--- a/annotator-core/src/main/java/edu/ucr/cs/riple/core/evaluators/graphprocessor/AbstractConflictGraphProcessor.java
+++ b/annotator-core/src/main/java/edu/ucr/cs/riple/core/evaluators/graphprocessor/AbstractConflictGraphProcessor.java
@@ -26,7 +26,7 @@ package edu.ucr.cs.riple.core.evaluators.graphprocessor;
 
 import edu.ucr.cs.riple.core.Config;
 import edu.ucr.cs.riple.core.evaluators.suppliers.Supplier;
-import edu.ucr.cs.riple.core.global.GlobalAnalyzer;
+import edu.ucr.cs.riple.core.global.DownstreamImpactCache;
 import edu.ucr.cs.riple.core.injectors.AnnotationInjector;
 import edu.ucr.cs.riple.core.metadata.graph.Node;
 import edu.ucr.cs.riple.core.metadata.index.ErrorStore;
@@ -46,8 +46,8 @@ public abstract class AbstractConflictGraphProcessor implements ConflictGraphPro
   protected final AnnotationInjector injector;
   /** Error store instance to store state of fixes before and after of injections. */
   protected final ErrorStore errorStore;
-  /** Global analyzer to retrieve impacts of fixes globally. */
-  protected final GlobalAnalyzer globalAnalyzer;
+  /** Downstream impact cache to retrieve impacts of fixes globally. */
+  protected final DownstreamImpactCache downstreamImpactCache;
   /** Annotator config. */
   protected final Config config;
   /** Handler to re-run compiler. */
@@ -58,7 +58,7 @@ public abstract class AbstractConflictGraphProcessor implements ConflictGraphPro
     this.methodDeclarationTree = supplier.getMethodDeclarationTree();
     this.injector = supplier.getInjector();
     this.errorStore = supplier.getErrorStore();
-    this.globalAnalyzer = supplier.getGlobalAnalyzer();
+    this.downstreamImpactCache = supplier.getDownstreamImpactCache();
     this.compilerRunner = runner;
   }
 
@@ -70,7 +70,7 @@ public abstract class AbstractConflictGraphProcessor implements ConflictGraphPro
   protected Set<Fix> getTriggeredFixesFromDownstream(Node node) {
     Set<Location> currentLocationTargetedByTree =
         node.tree.stream().map(Fix::toLocation).collect(Collectors.toSet());
-    return globalAnalyzer.getImpactedParameters(node.tree).stream()
+    return downstreamImpactCache.getImpactedParameters(node.tree).stream()
         .filter(input -> !currentLocationTargetedByTree.contains(input))
         .map(
             onParameter ->

--- a/annotator-core/src/main/java/edu/ucr/cs/riple/core/evaluators/suppliers/DownstreamDependencySupplier.java
+++ b/annotator-core/src/main/java/edu/ucr/cs/riple/core/evaluators/suppliers/DownstreamDependencySupplier.java
@@ -29,8 +29,8 @@ import edu.ucr.cs.riple.core.evaluators.graphprocessor.AbstractConflictGraphProc
 import edu.ucr.cs.riple.core.evaluators.graphprocessor.CompilerRunner;
 import edu.ucr.cs.riple.core.evaluators.graphprocessor.ParallelConflictGraphProcessor;
 import edu.ucr.cs.riple.core.evaluators.graphprocessor.SequentialConflictGraphProcessor;
-import edu.ucr.cs.riple.core.global.GlobalAnalyzer;
-import edu.ucr.cs.riple.core.global.NoOpGlobalAnalyzer;
+import edu.ucr.cs.riple.core.global.DownstreamImpactCache;
+import edu.ucr.cs.riple.core.global.VoidDownstreamImpactCache;
 import edu.ucr.cs.riple.core.injectors.AnnotationInjector;
 import edu.ucr.cs.riple.core.injectors.VirtualInjector;
 import edu.ucr.cs.riple.core.metadata.method.MethodDeclarationTree;
@@ -67,8 +67,8 @@ public class DownstreamDependencySupplier extends AbstractSupplier {
   }
 
   @Override
-  public GlobalAnalyzer getGlobalAnalyzer() {
-    return new NoOpGlobalAnalyzer();
+  public DownstreamImpactCache getDownstreamImpactCache() {
+    return new VoidDownstreamImpactCache();
   }
 
   @Override

--- a/annotator-core/src/main/java/edu/ucr/cs/riple/core/evaluators/suppliers/Supplier.java
+++ b/annotator-core/src/main/java/edu/ucr/cs/riple/core/evaluators/suppliers/Supplier.java
@@ -27,7 +27,7 @@ package edu.ucr.cs.riple.core.evaluators.suppliers;
 import edu.ucr.cs.riple.core.Config;
 import edu.ucr.cs.riple.core.evaluators.AbstractEvaluator;
 import edu.ucr.cs.riple.core.evaluators.graphprocessor.ConflictGraphProcessor;
-import edu.ucr.cs.riple.core.global.GlobalAnalyzer;
+import edu.ucr.cs.riple.core.global.DownstreamImpactCache;
 import edu.ucr.cs.riple.core.injectors.AnnotationInjector;
 import edu.ucr.cs.riple.core.metadata.index.Error;
 import edu.ucr.cs.riple.core.metadata.index.ErrorStore;
@@ -72,11 +72,11 @@ public interface Supplier {
   Config getConfig();
 
   /**
-   * Getter for {@link GlobalAnalyzer} instance.
+   * Getter for {@link DownstreamImpactCache} instance.
    *
-   * @return GlobalAnalyzer instance.
+   * @return DownstreamImpactCache instance.
    */
-  GlobalAnalyzer getGlobalAnalyzer();
+  DownstreamImpactCache getDownstreamImpactCache();
 
   /**
    * Getter for {@link ConflictGraphProcessor}.

--- a/annotator-core/src/main/java/edu/ucr/cs/riple/core/evaluators/suppliers/TargetModuleSupplier.java
+++ b/annotator-core/src/main/java/edu/ucr/cs/riple/core/evaluators/suppliers/TargetModuleSupplier.java
@@ -30,7 +30,7 @@ import edu.ucr.cs.riple.core.evaluators.graphprocessor.CompilerRunner;
 import edu.ucr.cs.riple.core.evaluators.graphprocessor.ConflictGraphProcessor;
 import edu.ucr.cs.riple.core.evaluators.graphprocessor.ParallelConflictGraphProcessor;
 import edu.ucr.cs.riple.core.evaluators.graphprocessor.SequentialConflictGraphProcessor;
-import edu.ucr.cs.riple.core.global.GlobalAnalyzer;
+import edu.ucr.cs.riple.core.global.DownstreamImpactCache;
 import edu.ucr.cs.riple.core.injectors.AnnotationInjector;
 import edu.ucr.cs.riple.core.injectors.PhysicalInjector;
 import edu.ucr.cs.riple.core.metadata.method.MethodDeclarationTree;
@@ -49,19 +49,19 @@ import edu.ucr.cs.riple.core.util.Utility;
  */
 public class TargetModuleSupplier extends AbstractSupplier {
 
-  protected final GlobalAnalyzer globalAnalyzer;
+  protected final DownstreamImpactCache downstreamImpactCache;
 
   /**
    * Constructor for target module supplier instance.
    *
    * @param config Annotator config instance.
-   * @param globalAnalyzer Global analyzer instance.
+   * @param downstreamImpactCache Global analyzer instance.
    * @param tree Method declaration tree for methods in target module.
    */
   public TargetModuleSupplier(
-      Config config, GlobalAnalyzer globalAnalyzer, MethodDeclarationTree tree) {
+      Config config, DownstreamImpactCache downstreamImpactCache, MethodDeclarationTree tree) {
     super(ImmutableSet.of(config.target), config, tree);
-    this.globalAnalyzer = globalAnalyzer;
+    this.downstreamImpactCache = downstreamImpactCache;
   }
 
   @Override
@@ -75,8 +75,8 @@ public class TargetModuleSupplier extends AbstractSupplier {
   }
 
   @Override
-  public GlobalAnalyzer getGlobalAnalyzer() {
-    return globalAnalyzer;
+  public DownstreamImpactCache getDownstreamImpactCache() {
+    return downstreamImpactCache;
   }
 
   @Override

--- a/annotator-core/src/main/java/edu/ucr/cs/riple/core/global/DownstreamImpactCache.java
+++ b/annotator-core/src/main/java/edu/ucr/cs/riple/core/global/DownstreamImpactCache.java
@@ -39,7 +39,7 @@ import java.util.Set;
  * of additional errors) of each such change, by summing across all downstream dependencies. This
  * data then be fed to the Annotator main process in the decision process.
  */
-public interface GlobalAnalyzer {
+public interface DownstreamImpactCache {
 
   /** Analyzes effects of changes in public methods in downstream dependencies. */
   void analyzeDownstreamDependencies();

--- a/annotator-core/src/main/java/edu/ucr/cs/riple/core/global/DownstreamImpactCacheImpl.java
+++ b/annotator-core/src/main/java/edu/ucr/cs/riple/core/global/DownstreamImpactCacheImpl.java
@@ -48,8 +48,8 @@ import java.util.stream.Collectors;
 import java.util.stream.Stream;
 import javax.annotation.Nullable;
 
-/** Implementation for {@link GlobalAnalyzer} interface. */
-public class GlobalAnalyzerImpl implements GlobalAnalyzer {
+/** Implementation for {@link DownstreamImpactCache} interface. */
+public class DownstreamImpactCacheImpl implements DownstreamImpactCache {
 
   /** Set of downstream dependencies. */
   private final ImmutableSet<ModuleInfo> downstreamModules;
@@ -60,7 +60,7 @@ public class GlobalAnalyzerImpl implements GlobalAnalyzer {
   /** Method declaration tree instance. */
   private final MethodDeclarationTree tree;
 
-  public GlobalAnalyzerImpl(Config config, MethodDeclarationTree tree) {
+  public DownstreamImpactCacheImpl(Config config, MethodDeclarationTree tree) {
     this.config = config;
     this.downstreamModules = config.downstreamInfo;
     this.tree = tree;

--- a/annotator-core/src/main/java/edu/ucr/cs/riple/core/global/DownstreamImpactEvaluator.java
+++ b/annotator-core/src/main/java/edu/ucr/cs/riple/core/global/DownstreamImpactEvaluator.java
@@ -36,9 +36,9 @@ import java.util.Set;
 import java.util.stream.Collectors;
 
 /**
- * Evaluator for analyzing downstream dependencies. Used by {@link GlobalAnalyzerImpl} to compute
- * the effects of changes in upstream on downstream dependencies. This evaluator cannot be used to
- * compute the effects in target module.
+ * Evaluator for analyzing downstream dependencies. Used by {@link DownstreamImpactCacheImpl} to
+ * compute the effects of changes in upstream on downstream dependencies. This evaluator cannot be
+ * used to compute the effects in target module.
  */
 class DownstreamImpactEvaluator extends BasicEvaluator {
 

--- a/annotator-core/src/main/java/edu/ucr/cs/riple/core/global/VoidDownstreamImpactCache.java
+++ b/annotator-core/src/main/java/edu/ucr/cs/riple/core/global/VoidDownstreamImpactCache.java
@@ -31,11 +31,11 @@ import edu.ucr.cs.riple.injector.location.OnParameter;
 import java.util.Set;
 
 /**
- * This global analyzer does not have any information regarding the impact of changes in target
- * module in dependencies, the main purpose of this class is to avoid initializing GlobalAnalyzer
- * instances to {@code null} when impact on dependencies is not considered.
+ * This downstream impact cache does not have any information regarding the impact of changes in
+ * target module in dependencies, the main purpose of this class is to avoid initializing
+ * DownstreamImpactCache instances to {@code null} when impact on dependencies is not considered.
  */
-public class NoOpGlobalAnalyzer implements GlobalAnalyzer {
+public class VoidDownstreamImpactCache implements DownstreamImpactCache {
 
   @Override
   public void analyzeDownstreamDependencies() {

--- a/annotator-core/src/main/java/edu/ucr/cs/riple/core/metadata/graph/Node.java
+++ b/annotator-core/src/main/java/edu/ucr/cs/riple/core/metadata/graph/Node.java
@@ -62,7 +62,7 @@ public class Node {
    * Set of triggered fixes on target module that will be triggered if fix tree is applied due to
    * errors in downstream dependencies.
    */
-  public ImmutableSet<Fix> triggeredFixesOnDownstream;
+  public ImmutableSet<Fix> triggeredFixesFromDownstream;
 
   /** Unique id of Node across all nodes. */
   public int id;
@@ -79,7 +79,7 @@ public class Node {
   public Node(Fix root) {
     this.regions = new HashSet<>();
     this.root = root;
-    this.triggeredFixesOnDownstream = ImmutableSet.of();
+    this.triggeredFixesFromDownstream = ImmutableSet.of();
     this.triggeredErrors = ImmutableSet.of();
     this.effect = 0;
     this.tree = Sets.newHashSet(root);
@@ -148,7 +148,7 @@ public class Node {
       Collection<Error> triggeredErrors,
       MethodDeclarationTree mdt) {
     // Update list of triggered fixes on downstream.
-    this.triggeredFixesOnDownstream = ImmutableSet.copyOf(triggeredFixesFromDownstream);
+    this.triggeredFixesFromDownstream = ImmutableSet.copyOf(triggeredFixesFromDownstream);
     // Update set of triggered errors.
     this.triggeredErrors = ImmutableSet.copyOf(triggeredErrors);
     // A fix in a tree, can have a super method that is not part of this node's tree but be present
@@ -189,7 +189,7 @@ public class Node {
   /** Merges triggered fixes to the tree, to prepare the analysis for the next depth. */
   public void mergeTriggered() {
     this.tree.addAll(Error.getResolvingFixesOfErrors(this.triggeredErrors));
-    this.tree.addAll(triggeredFixesOnDownstream);
+    this.tree.addAll(triggeredFixesFromDownstream);
     this.tree.forEach(fix -> fix.fixSourceIsInTarget = true);
   }
 


### PR DESCRIPTION
This PR simply includes renaming in #111 (through received comments in reviews). The purpose of this PR is to make #111 more understandable as this change is unrelated to #111. I am going to land this since it is a very straightforward name change. Please let me know if you would like to discuss more regarding this change and I will bring this back. Thank you. @msridhar @lazaroclapp. 

Renames are:
1. `triggeredFixesOnDownstream` to `triggeredFixesFromDownstream`.
2. `globalAnalyzer` to `downstreamImpactCache`.