### PR TITLE
Extend impacted regions by a method change

### DIFF
--- a/annotator-core/src/main/java/edu/ucr/cs/riple/core/metadata/trackers/MethodRegionTracker.java
+++ b/annotator-core/src/main/java/edu/ucr/cs/riple/core/metadata/trackers/MethodRegionTracker.java
@@ -47,7 +47,7 @@ public class MethodRegionTracker extends MetaData<TrackerNode> implements Region
   private final MethodDeclarationTree tree;
 
   public MethodRegionTracker(Config config, ModuleInfo info, MethodDeclarationTree tree) {
-    super(config, info.dir.resolve(Serializer.CALL_GRAPH_FILE_NAME));
+    super(config, info.dir.resolve(Serializer.METHOD_IMPACTED_REGION_FILE_NAME));
     this.tree = tree;
   }
 
@@ -56,7 +56,7 @@ public class MethodRegionTracker extends MetaData<TrackerNode> implements Region
     super(
         config,
         modules.stream()
-            .map(info -> info.dir.resolve(Serializer.CALL_GRAPH_FILE_NAME))
+            .map(info -> info.dir.resolve(Serializer.METHOD_IMPACTED_REGION_FILE_NAME))
             .collect(ImmutableSet.toImmutableSet()));
     this.tree = tree;
   }

--- a/annotator-core/src/test/java/edu/ucr/cs/riple/core/CoreTest.java
+++ b/annotator-core/src/test/java/edu/ucr/cs/riple/core/CoreTest.java
@@ -453,7 +453,7 @@ public class CoreTest extends BaseCoreTest {
   }
 
   @Test
-  public void impactedLambdaAndMemberReferenceTest() {
+  public void impactedLambdaAndMemberReferenceParameterNullableTest() {
     coreTestHelper
         .addInputLines(
             "Main.java",
@@ -475,7 +475,7 @@ public class CoreTest extends BaseCoreTest {
             "   public void baz3() {",
             "       f(this::take);",
             "   }",
-            "   public Object take(Object o){ return null; }",
+            "   public void take(Object o){ }",
             "   public void passNull(Foo foo) {",
             "       foo.bar(null);",
             "   }",
@@ -483,8 +483,34 @@ public class CoreTest extends BaseCoreTest {
         .addInputLines(
             "Foo.java", "package test;", "public interface Foo{", "     void bar(Object o);", "}")
         .addExpectedReports(
-            new TReport(new OnParameter("Foo.java", "test.Foo", "bar(java.lang.Object)", 0), 2),
-            new TReport(new OnMethod("Main.java", "test.Main", "take(java.lang.Object)"), 0))
+            new TReport(new OnParameter("Foo.java", "test.Foo", "bar(java.lang.Object)", 0), 2))
+        .toDepth(1)
+        .start();
+  }
+
+  @Test
+  public void impactedLambdaAndMemberReferenceReturnNullableTest() {
+    coreTestHelper
+        .addInputLines(
+            "Main.java",
+            "package test;",
+            "import javax.annotation.Nullable;",
+            "public class Main {",
+            "   public void f(Foo r){ }",
+            "   public void baz1() {",
+            "       f(e -> bar(e));",
+            "   }",
+            "   public void baz2() {",
+            "       f(this::bar);",
+            "   }",
+            "   public Object bar(Object o){",
+            "       return null;",
+            "   }",
+            "}")
+        .addInputLines(
+            "Foo.java", "package test;", "public interface Foo{", "     Object m(Object o);", "}")
+        .addExpectedReports(
+            new TReport(new OnMethod("Foo.java", "test.Main", "bar(java.lang.Object)"), 1))
         .toDepth(1)
         .start();
   }

--- a/annotator-core/src/test/java/edu/ucr/cs/riple/core/CoreTest.java
+++ b/annotator-core/src/test/java/edu/ucr/cs/riple/core/CoreTest.java
@@ -460,7 +460,7 @@ public class CoreTest extends BaseCoreTest {
             "   public void baz3() {",
             "       f(this::take);",
             "   }",
-            "   public void take(Object o){}",
+            "   public Object take(Object o){ return null; }",
             "   public void passNull(Foo foo) {",
             "       foo.bar(null);",
             "   }",
@@ -468,7 +468,8 @@ public class CoreTest extends BaseCoreTest {
         .addInputLines(
             "Foo.java", "package test;", "public interface Foo{", "     void bar(Object o);", "}")
         .addExpectedReports(
-            new TReport(new OnParameter("Foo.java", "test.Foo", "bar(java.lang.Object)", 0), 2))
+            new TReport(new OnParameter("Foo.java", "test.Foo", "bar(java.lang.Object)", 0), 2),
+            new TReport(new OnMethod("Main.java", "test.Main", "take(java.lang.Object)"), 0))
         .toDepth(1)
         .start();
   }

--- a/annotator-scanner/src/main/java/edu/ucr/cs/riple/scanner/AnnotatorScanner.java
+++ b/annotator-scanner/src/main/java/edu/ucr/cs/riple/scanner/AnnotatorScanner.java
@@ -107,7 +107,7 @@ public class AnnotatorScanner extends BugChecker
     }
     config
         .getSerializer()
-        .serializeCallGraphNode(
+        .serializeImpactedRegionByMethod(
             new TrackerNode(config, ASTHelpers.getSymbol(tree), state.getPath()));
     return Description.NO_MATCH;
   }
@@ -117,7 +117,7 @@ public class AnnotatorScanner extends BugChecker
     Config config = context.getConfig();
     config
         .getSerializer()
-        .serializeCallGraphNode(
+        .serializeImpactedRegionByMethod(
             new TrackerNode(config, ASTHelpers.getSymbol(tree), state.getPath()));
     return Description.NO_MATCH;
   }
@@ -194,7 +194,8 @@ public class AnnotatorScanner extends BugChecker
         context
             .getConfig()
             .getSerializer()
-            .serializeCallGraphNode(new TrackerNode(config, calledMethod, visitorState.getPath()));
+            .serializeImpactedRegionByMethod(
+                new TrackerNode(config, calledMethod, visitorState.getPath()));
       }
     }
     return Description.NO_MATCH;
@@ -229,6 +230,6 @@ public class AnnotatorScanner extends BugChecker
     }
     config
         .getSerializer()
-        .serializeCallGraphNode(new TrackerNode(config, methodSym, state.getPath()));
+        .serializeImpactedRegionByMethod(new TrackerNode(config, methodSym, state.getPath()));
   }
 }

--- a/annotator-scanner/src/main/java/edu/ucr/cs/riple/scanner/AnnotatorScanner.java
+++ b/annotator-scanner/src/main/java/edu/ucr/cs/riple/scanner/AnnotatorScanner.java
@@ -176,7 +176,7 @@ public class AnnotatorScanner extends BugChecker
     if (!config.callTrackerIsActive()) {
       return Description.NO_MATCH;
     }
-    serializeFunctionalInterface(config, lambdaExpressionTree, visitorState);
+    serializeImpactedRegionForFunctionalInterface(config, lambdaExpressionTree, visitorState);
     return Description.NO_MATCH;
   }
 
@@ -187,7 +187,7 @@ public class AnnotatorScanner extends BugChecker
     if (!config.callTrackerIsActive()) {
       return Description.NO_MATCH;
     }
-    serializeFunctionalInterface(config, memberReferenceTree, visitorState);
+    serializeImpactedRegionForFunctionalInterface(config, memberReferenceTree, visitorState);
     if (memberReferenceTree instanceof JCTree.JCMemberReference) {
       Symbol calledMethod = ((JCTree.JCMemberReference) memberReferenceTree).sym;
       if (calledMethod instanceof Symbol.MethodSymbol) {
@@ -217,12 +217,13 @@ public class AnnotatorScanner extends BugChecker
   }
 
   /**
-   * Serializes the functional interface.
+   * Serializes the impacted region for a functional interface. The serialized region might be
+   * impacted by any change on the passed tree.
    *
    * @param tree Given tree.
    * @param state Visitor State.
    */
-  private static void serializeFunctionalInterface(
+  private static void serializeImpactedRegionForFunctionalInterface(
       Config config, ExpressionTree tree, VisitorState state) {
     Symbol.MethodSymbol methodSym = SymbolUtil.getFunctionalInterfaceMethod(tree, state.getTypes());
     if (methodSym == null) {

--- a/annotator-scanner/src/main/java/edu/ucr/cs/riple/scanner/AnnotatorScanner.java
+++ b/annotator-scanner/src/main/java/edu/ucr/cs/riple/scanner/AnnotatorScanner.java
@@ -191,8 +191,8 @@ public class AnnotatorScanner extends BugChecker
       return Description.NO_MATCH;
     }
     // for Foo::bar, which is shorthand for e -> Foo.bar(e), assume that method "baz()" has been
-    // overridden. We need to serialize the region (leaf of path in visitor state)
-    // for both "baz()" and the called method "bar()" as an impacted region".
+    // overridden. We need to serialize the impacted region (leaf of path in visitor state)
+    // for both "baz()" and also the called method "bar()".
     // serialize the overridden method: "baz()"
     serializeImpactedRegionForFunctionalInterface(config, memberReferenceTree, visitorState);
     if (memberReferenceTree instanceof JCTree.JCMemberReference) {

--- a/annotator-scanner/src/main/java/edu/ucr/cs/riple/scanner/AnnotatorScanner.java
+++ b/annotator-scanner/src/main/java/edu/ucr/cs/riple/scanner/AnnotatorScanner.java
@@ -236,6 +236,12 @@ public class AnnotatorScanner extends BugChecker
       Config config, ExpressionTree tree, VisitorState state) {
     Symbol.MethodSymbol methodSym = SymbolUtil.getFunctionalInterfaceMethod(tree, state.getTypes());
     if (methodSym == null) {
+      System.err.println(
+          "Expected a nonnull method symbol for functional interface:"
+              + state.getSourceForNode(tree)
+              + ", at path: "
+              + state.getPath().getCompilationUnit().getSourceFile().toUri()
+              + ", but received null.");
       return;
     }
     config

--- a/annotator-scanner/src/main/java/edu/ucr/cs/riple/scanner/AnnotatorScanner.java
+++ b/annotator-scanner/src/main/java/edu/ucr/cs/riple/scanner/AnnotatorScanner.java
@@ -176,6 +176,8 @@ public class AnnotatorScanner extends BugChecker
     if (!config.callTrackerIsActive()) {
       return Description.NO_MATCH;
     }
+    // for e -> Foo.bar(e), assume that method "baz()" has been overridden. We need to serialize the
+    // region (leaf of path in visitor state) for "baz()".
     serializeImpactedRegionForFunctionalInterface(config, lambdaExpressionTree, visitorState);
     return Description.NO_MATCH;
   }
@@ -188,8 +190,8 @@ public class AnnotatorScanner extends BugChecker
       return Description.NO_MATCH;
     }
     // for Foo::bar, which is shorthand for e -> Foo.bar(e), assume that method "baz()" has been
-    // overridden. We need to serialize the region (leaf of path in visitor state) in visitor state
-    // for both "baz()" and the called method "bar() as an impacted region".
+    // overridden. We need to serialize the region (leaf of path in visitor state)
+    // for both "baz()" and the called method "bar()" as an impacted region".
     // serialize the overridden method: "baz()"
     serializeImpactedRegionForFunctionalInterface(config, memberReferenceTree, visitorState);
     if (memberReferenceTree instanceof JCTree.JCMemberReference) {

--- a/annotator-scanner/src/main/java/edu/ucr/cs/riple/scanner/AnnotatorScanner.java
+++ b/annotator-scanner/src/main/java/edu/ucr/cs/riple/scanner/AnnotatorScanner.java
@@ -107,7 +107,7 @@ public class AnnotatorScanner extends BugChecker
     }
     config
         .getSerializer()
-        .serializeImpactedRegionByMethod(
+        .serializeImpactedRegionForMethod(
             new ImpactedRegion(config, ASTHelpers.getSymbol(tree), state.getPath()));
     return Description.NO_MATCH;
   }
@@ -117,7 +117,7 @@ public class AnnotatorScanner extends BugChecker
     Config config = context.getConfig();
     config
         .getSerializer()
-        .serializeImpactedRegionByMethod(
+        .serializeImpactedRegionForMethod(
             new ImpactedRegion(config, ASTHelpers.getSymbol(tree), state.getPath()));
     return Description.NO_MATCH;
   }
@@ -202,7 +202,7 @@ public class AnnotatorScanner extends BugChecker
         context
             .getConfig()
             .getSerializer()
-            .serializeImpactedRegionByMethod(
+            .serializeImpactedRegionForMethod(
                 new ImpactedRegion(config, calledMethod, visitorState.getPath()));
       }
     }
@@ -247,6 +247,6 @@ public class AnnotatorScanner extends BugChecker
     }
     config
         .getSerializer()
-        .serializeImpactedRegionByMethod(new ImpactedRegion(config, methodSym, state.getPath()));
+        .serializeImpactedRegionForMethod(new ImpactedRegion(config, methodSym, state.getPath()));
   }
 }

--- a/annotator-scanner/src/main/java/edu/ucr/cs/riple/scanner/AnnotatorScanner.java
+++ b/annotator-scanner/src/main/java/edu/ucr/cs/riple/scanner/AnnotatorScanner.java
@@ -224,8 +224,9 @@ public class AnnotatorScanner extends BugChecker
   }
 
   /**
-   * Serializes the impacted region for a functional interface. The serialized region might be
-   * impacted by any change on the passed tree.
+   * Serializes the impacted region for a functional interface. This method locates the overriden
+   * method from the passed functional interface tree and serializes the impacted region for that
+   * method.
    *
    * @param tree Given tree.
    * @param state Visitor State.

--- a/annotator-scanner/src/main/java/edu/ucr/cs/riple/scanner/AnnotatorScanner.java
+++ b/annotator-scanner/src/main/java/edu/ucr/cs/riple/scanner/AnnotatorScanner.java
@@ -176,8 +176,9 @@ public class AnnotatorScanner extends BugChecker
     if (!config.callTrackerIsActive()) {
       return Description.NO_MATCH;
     }
-    // for e -> Foo.bar(e), assume that method "baz()" has been overridden. We need to serialize the
-    // region (leaf of path in visitor state) for "baz()".
+    // for e -> Foo.bar(e), assume that method "baz()" has been overridden. Then the containing
+    // method for this lambda is an impacted region for "baz()".  The call to "Foo.bar" is handled
+    // when scanning the body of the lambda.
     serializeImpactedRegionForFunctionalInterface(config, lambdaExpressionTree, visitorState);
     return Description.NO_MATCH;
   }

--- a/annotator-scanner/src/main/java/edu/ucr/cs/riple/scanner/AnnotatorScanner.java
+++ b/annotator-scanner/src/main/java/edu/ucr/cs/riple/scanner/AnnotatorScanner.java
@@ -187,10 +187,15 @@ public class AnnotatorScanner extends BugChecker
     if (!config.callTrackerIsActive()) {
       return Description.NO_MATCH;
     }
+    // for Foo::bar, which is shorthand for e -> Foo.bar(e), assume that method "baz()" has been
+    // overridden. We need to serialize the region (leaf of path in visitor state) in visitor state
+    // for both "baz()" and the called method "bar() as an impacted region".
+    // serialize the overridden method: "baz()"
     serializeImpactedRegionForFunctionalInterface(config, memberReferenceTree, visitorState);
     if (memberReferenceTree instanceof JCTree.JCMemberReference) {
       Symbol calledMethod = ((JCTree.JCMemberReference) memberReferenceTree).sym;
       if (calledMethod instanceof Symbol.MethodSymbol) {
+        // serialize the called method: "bar()"
         context
             .getConfig()
             .getSerializer()

--- a/annotator-scanner/src/main/java/edu/ucr/cs/riple/scanner/Serializer.java
+++ b/annotator-scanner/src/main/java/edu/ucr/cs/riple/scanner/Serializer.java
@@ -52,7 +52,7 @@ public class Serializer {
   /** File name where all field usage data has been stored. */
   public static final String FIELD_GRAPH_FILE_NAME = "field_graph.tsv";
   /** File name where all impacted regions for changes on methods are serialized. */
-  public static final String METHOD_IMPACTED_REGION_FILE_NAME = "impacted_region.tsv";
+  public static final String METHOD_IMPACTED_REGION_FILE_NAME = "method_impacted_region_map.tsv";
   /** File name where all method data has been stored. */
   public static final String METHOD_INFO_FILE_NAME = "method_info.tsv";
   /** File name where all class data has been stored. */

--- a/annotator-scanner/src/main/java/edu/ucr/cs/riple/scanner/Serializer.java
+++ b/annotator-scanner/src/main/java/edu/ucr/cs/riple/scanner/Serializer.java
@@ -42,8 +42,8 @@ public class Serializer {
 
   /** Path to write field graph. */
   private final Path fieldGraphPath;
-  /** Path to write method call graph. */
-  private final Path callGraphPath;
+  /** Path to write impacted regions for changes on methods */
+  private final Path methodImpactedRegion;
   /** Path to write method info metadata. */
   private final Path methodInfoPath;
   /** Path to write class info data. */
@@ -51,8 +51,8 @@ public class Serializer {
 
   /** File name where all field usage data has been stored. */
   public static final String FIELD_GRAPH_FILE_NAME = "field_graph.tsv";
-  /** File name where all method invocations data has been stored. */
-  public static final String CALL_GRAPH_FILE_NAME = "call_graph.tsv";
+  /** File name where all impacted regions for changes on methods are serialized. */
+  public static final String METHOD_IMPACTED_REGION_FILE_NAME = "impacted_region.tsv";
   /** File name where all method data has been stored. */
   public static final String METHOD_INFO_FILE_NAME = "method_info.tsv";
   /** File name where all class data has been stored. */
@@ -61,19 +61,21 @@ public class Serializer {
   public Serializer(Config config) {
     Path outputDirectory = config.getOutputDirectory();
     this.fieldGraphPath = outputDirectory.resolve(FIELD_GRAPH_FILE_NAME);
-    this.callGraphPath = outputDirectory.resolve(CALL_GRAPH_FILE_NAME);
+    this.methodImpactedRegion = outputDirectory.resolve(METHOD_IMPACTED_REGION_FILE_NAME);
     this.methodInfoPath = outputDirectory.resolve(METHOD_INFO_FILE_NAME);
     this.classInfoPath = outputDirectory.resolve(CLASS_INFO_FILE_NAME);
     initializeOutputFiles(config);
   }
 
   /**
-   * Appends the string representation of the {@link TrackerNode} corresponding to a call graph.
+   * Appends the string representation of the {@link TrackerNode} corresponding to method impacted
+   * region.
    *
-   * @param callGraphNode TrackerNode instance.
+   * @param methodImpactedRegion TrackerNode instance which is an impacted region for a method
+   *     change.
    */
-  public void serializeCallGraphNode(TrackerNode callGraphNode) {
-    appendToFile(callGraphNode.toString(), this.callGraphPath);
+  public void serializeImpactedRegionByMethod(TrackerNode methodImpactedRegion) {
+    appendToFile(methodImpactedRegion.toString(), this.methodImpactedRegion);
   }
 
   /**
@@ -125,7 +127,7 @@ public class Serializer {
     try {
       Files.createDirectories(config.getOutputDirectory());
       if (config.callTrackerIsActive()) {
-        initializeFile(callGraphPath, TrackerNode.header());
+        initializeFile(methodImpactedRegion, TrackerNode.header());
       }
       if (config.fieldTrackerIsActive()) {
         initializeFile(fieldGraphPath, TrackerNode.header());

--- a/annotator-scanner/src/main/java/edu/ucr/cs/riple/scanner/Serializer.java
+++ b/annotator-scanner/src/main/java/edu/ucr/cs/riple/scanner/Serializer.java
@@ -68,14 +68,13 @@ public class Serializer {
   }
 
   /**
-   * Appends the string representation of the {@link ImpactedRegion} corresponding to method
-   * impacted region.
+   * Appends the string representation of the {@link ImpactedRegion} which is a region (field,
+   * method or a static initialization block) that is impacted by a change on a method.
    *
-   * @param methodImpactedRegion TrackerNode instance which is an impacted region for a method
-   *     change.
+   * @param impactedRegion ImpactedRegion instance which will be serialized to output.
    */
-  public void serializeImpactedRegionByMethod(ImpactedRegion methodImpactedRegion) {
-    appendToFile(methodImpactedRegion.toString(), this.methodImpactedRegion);
+  public void serializeImpactedRegionForMethod(ImpactedRegion impactedRegion) {
+    appendToFile(impactedRegion.toString(), this.methodImpactedRegion);
   }
 
   /**

--- a/annotator-scanner/src/main/java/edu/ucr/cs/riple/scanner/SymbolUtil.java
+++ b/annotator-scanner/src/main/java/edu/ucr/cs/riple/scanner/SymbolUtil.java
@@ -26,7 +26,11 @@
 
 package edu.ucr.cs.riple.scanner;
 
+import com.google.common.base.Preconditions;
 import com.google.errorprone.util.ASTHelpers;
+import com.sun.source.tree.ExpressionTree;
+import com.sun.source.tree.LambdaExpressionTree;
+import com.sun.source.tree.MemberReferenceTree;
 import com.sun.source.tree.MethodTree;
 import com.sun.source.tree.VariableTree;
 import com.sun.source.util.TreePath;
@@ -35,6 +39,7 @@ import com.sun.tools.javac.code.Symbol;
 import com.sun.tools.javac.code.TargetType;
 import com.sun.tools.javac.code.Type;
 import com.sun.tools.javac.code.Types;
+import com.sun.tools.javac.tree.JCTree;
 import java.util.stream.Stream;
 import javax.annotation.Nullable;
 import javax.lang.model.element.AnnotationMirror;
@@ -201,5 +206,19 @@ public class SymbolUtil {
       return fieldSymbol;
     }
     return null;
+  }
+
+  /**
+   * finds the corresponding functional interface method for a lambda expression or a method
+   * reference
+   *
+   * @param tree the lambda expression or method reference
+   * @return the functional interface method
+   */
+  public static Symbol.MethodSymbol getFunctionalInterfaceMethod(ExpressionTree tree, Types types) {
+    Preconditions.checkArgument(
+        (tree instanceof LambdaExpressionTree) || (tree instanceof MemberReferenceTree));
+    Type funcInterfaceType = ((JCTree.JCFunctionalExpression) tree).type;
+    return (Symbol.MethodSymbol) types.findDescriptorSymbol(funcInterfaceType.tsym);
   }
 }

--- a/annotator-scanner/src/test/java/edu/ucr/cs/riple/scanner/MethodImpactedRegionTest.java
+++ b/annotator-scanner/src/test/java/edu/ucr/cs/riple/scanner/MethodImpactedRegionTest.java
@@ -49,7 +49,7 @@ public class MethodImpactedRegionTest extends AnnotatorScannerBaseTest<TrackerNo
           + "USED_CLASS"
           + '\t'
           + "SOURCE_TYPE";
-  private static final String FILE_NAME = "call_graph.tsv";
+  private static final String FILE_NAME = "method_impacted_region_map.tsv";
 
   public MethodImpactedRegionTest() {
     super(METHOD_TRACKER_DISPLAY_FACTORY, HEADER, FILE_NAME);

--- a/annotator-scanner/src/test/java/edu/ucr/cs/riple/scanner/MethodImpactedRegionTest.java
+++ b/annotator-scanner/src/test/java/edu/ucr/cs/riple/scanner/MethodImpactedRegionTest.java
@@ -32,7 +32,7 @@ import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
 
 @RunWith(JUnit4.class)
-public class MethodCallTrackerTest extends AnnotatorScannerBaseTest<TrackerNodeDisplay> {
+public class MethodImpactedRegionTest extends AnnotatorScannerBaseTest<TrackerNodeDisplay> {
 
   private static final DisplayFactory<TrackerNodeDisplay> METHOD_TRACKER_DISPLAY_FACTORY =
       values -> {
@@ -51,7 +51,7 @@ public class MethodCallTrackerTest extends AnnotatorScannerBaseTest<TrackerNodeD
           + "SOURCE_TYPE";
   private static final String FILE_NAME = "call_graph.tsv";
 
-  public MethodCallTrackerTest() {
+  public MethodImpactedRegionTest() {
     super(METHOD_TRACKER_DISPLAY_FACTORY, HEADER, FILE_NAME);
   }
 

--- a/annotator-scanner/src/test/java/edu/ucr/cs/riple/scanner/MethodImpactedRegionTest.java
+++ b/annotator-scanner/src/test/java/edu/ucr/cs/riple/scanner/MethodImpactedRegionTest.java
@@ -77,53 +77,6 @@ public class MethodImpactedRegionTest extends AnnotatorScannerBaseTest<TrackerNo
   }
 
   @Test
-  public void fieldDeclaredRegionComputationAllCases() {
-    tester
-        .addSourceLines(
-            "edu/ucr/A.java",
-            "package edu.ucr;",
-            "public class A {",
-            "   B b = new B();",
-            "   Object f0 = b.get();",
-            "   Object f1 = B.staticB();",
-            "   Object f2 = b.c.get();",
-            "   Object f3 = B.staticC.get();",
-            "   {",
-            "       B.staticB();",
-            "   }",
-            "}",
-            "class B {",
-            "   C c = new C();",
-            "   static C staticC = new C();",
-            "   Object get() {",
-            "       return new Object();",
-            "   }",
-            "   static Object staticB() {",
-            "       return new Object();",
-            "   }",
-            "}",
-            "class C {",
-            "   Object val;",
-            "   static Object get() {",
-            "       return new Object();",
-            "   }",
-            "}")
-        .setExpectedOutputs(
-            new TrackerNodeDisplay("edu.ucr.A", "f0", "edu.ucr.B", "get()"),
-            new TrackerNodeDisplay("edu.ucr.A", "b", "edu.ucr.B", "B()"),
-            new TrackerNodeDisplay("edu.ucr.A", "f1", "edu.ucr.B", "staticB()"),
-            new TrackerNodeDisplay("edu.ucr.A", "f2", "edu.ucr.C", "get()"),
-            new TrackerNodeDisplay("edu.ucr.A", "f3", "edu.ucr.C", "get()"),
-            new TrackerNodeDisplay("edu.ucr.A", "null", "edu.ucr.B", "staticB()"),
-            new TrackerNodeDisplay("edu.ucr.B", "c", "edu.ucr.C", "C()"),
-            new TrackerNodeDisplay("edu.ucr.B", "get()", "java.lang.Object", "Object()"),
-            new TrackerNodeDisplay("edu.ucr.B", "staticB()", "java.lang.Object", "Object()"),
-            new TrackerNodeDisplay("edu.ucr.B", "staticC", "edu.ucr.C", "C()"),
-            new TrackerNodeDisplay("edu.ucr.C", "get()", "java.lang.Object", "Object()"))
-        .doTest();
-  }
-
-  @Test
   public void constructorCallTest() {
     tester
         .addSourceLines(


### PR DESCRIPTION
This pull request extends the set of impacted regions for changes made to methods. Prior to this pull request, only call sites (and overriding methods) were taken into consideration as impacted regions for changes to methods. However, the use of lambda expressions or method references can actually extend the set of impacted regions and these should also be included. See example below:

```java
public class Main {

    public void f(Foo r){ }

    public void baz1(){
        f(new Foo(){
            public void bar(Object o){
                t(o);
            }
        });
    }

    public void baz2(){
        f(e -> t(e));
    }

     public void baz3(){
        f(this::t);
    }

    public void t(Object o){ }
}

interface Foo{
    void bar(Object o);
}
```

For example, if the `o` parameter of the `bar` method in `Foo` is annotated as `@Nullable`, the regions `baz2` and `baz3` were previously not included as impacted regions since there is no trace of bar in these methods in the current implementation. As a result, the triggered errors (such as `passing @Nullable for t(Object)`) will not be caught by the annotator. This pull request addresses this issue and extends the set of impacted regions to include `baz2()` and `baz3()` for changes made to `Foo#bar()`.

This PR also renames the output `call_graph.tsv` to `method_impacted_region_map.tsv` to better reflect its new content as it is no longer limited to just call sites, but now also includes the additional regions.