### PR TITLE
Add @NullUnmarked on constructors

### DIFF
--- a/annotator-core/src/main/java/edu/ucr/cs/riple/core/Annotator.java
+++ b/annotator-core/src/main/java/edu/ucr/cs/riple/core/Annotator.java
@@ -238,7 +238,12 @@ public class Annotator {
             // find the corresponding method nodes.
             .map(
                 error -> {
-                  if (!error.isInitializationError() && error.getRegion().isOnCallable()) {
+                  if (error.getRegion().isOnCallable()
+                      &&
+                      // We suppress initialization errors reported on constructors using
+                      // @SuppressWarnings("NullAway.Init"). We add @NullUnmarked on constructors
+                      // only for errors in the body of the constructor.
+                      !error.isInitializationError()) {
                     return methodDeclarationTree.findNode(error.encMember(), error.encClass());
                   }
                   // For methods invoked in an initialization region, where the error is that

--- a/annotator-core/src/main/java/edu/ucr/cs/riple/core/Annotator.java
+++ b/annotator-core/src/main/java/edu/ucr/cs/riple/core/Annotator.java
@@ -302,8 +302,8 @@ public class Annotator {
             .filter(
                 fix ->
                     fix.isOnField()
-                        && (fix.reasons.contains("FIELD_NO_INIT")
-                            || fix.reasons.contains("METHOD_NO_INIT")))
+                        && (fix.reasons.contains("METHOD_NO_INIT")
+                            || fix.reasons.contains("FIELD_NO_INIT")))
             // Filter nodes annotated with SuppressWarnings("NullAway")
             .filter(fix -> !fieldsWithSuppressWarnings.contains(fix.toField()))
             .map(

--- a/annotator-core/src/main/java/edu/ucr/cs/riple/core/Annotator.java
+++ b/annotator-core/src/main/java/edu/ucr/cs/riple/core/Annotator.java
@@ -229,8 +229,6 @@ public class Annotator {
     Utility.buildTarget(config);
     Set<Error> remainingErrors =
         Utility.readErrorsFromOutputDirectory(config, config.target, fieldDeclarationStore);
-    System.out.println(
-        remainingErrors.size() + " errors remaining. Applying suppression annotations.");
     Set<Fix> remainingFixes = Utility.readFixesFromOutputDirectory(config, fieldDeclarationStore);
     // Collect all regions for NullUnmarked.
     // For all errors in regions which correspond to a method's body, we can add @NullUnmarked at

--- a/annotator-core/src/main/java/edu/ucr/cs/riple/core/Annotator.java
+++ b/annotator-core/src/main/java/edu/ucr/cs/riple/core/Annotator.java
@@ -240,7 +240,7 @@ public class Annotator {
             // find the corresponding method nodes.
             .map(
                 error -> {
-                  if (error.getRegion().isOnCallable()) {
+                  if (error.getRegion().isOnMethod()) {
                     return methodDeclarationTree.findNode(error.encMember(), error.encClass());
                   }
                   // For methods invoked in an initialization region, where the error is that

--- a/annotator-core/src/main/java/edu/ucr/cs/riple/core/Annotator.java
+++ b/annotator-core/src/main/java/edu/ucr/cs/riple/core/Annotator.java
@@ -238,7 +238,7 @@ public class Annotator {
             // find the corresponding method nodes.
             .map(
                 error -> {
-                  if (error.getRegion().isOnCallable()) {
+                  if (!error.isInitializationError() && error.getRegion().isOnCallable()) {
                     return methodDeclarationTree.findNode(error.encMember(), error.encClass());
                   }
                   // For methods invoked in an initialization region, where the error is that
@@ -274,8 +274,7 @@ public class Annotator {
                     return false;
                   }
                   // We can silence them by SuppressWarnings("NullAway.Init")
-                  return !error.messageType.equals("METHOD_NO_INIT")
-                      && !error.messageType.equals("FIELD_NO_INIT");
+                  return !error.isInitializationError();
                 })
             .map(
                 error ->

--- a/annotator-core/src/main/java/edu/ucr/cs/riple/core/Annotator.java
+++ b/annotator-core/src/main/java/edu/ucr/cs/riple/core/Annotator.java
@@ -229,6 +229,8 @@ public class Annotator {
     Utility.buildTarget(config);
     Set<Error> remainingErrors =
         Utility.readErrorsFromOutputDirectory(config, config.target, fieldDeclarationStore);
+    System.out.println(
+        remainingErrors.size() + " errors remaining. Applying suppression annotations.");
     Set<Fix> remainingFixes = Utility.readFixesFromOutputDirectory(config, fieldDeclarationStore);
     // Collect all regions for NullUnmarked.
     // For all errors in regions which correspond to a method's body, we can add @NullUnmarked at
@@ -238,7 +240,7 @@ public class Annotator {
             // find the corresponding method nodes.
             .map(
                 error -> {
-                  if (error.getRegion().isOnMethod()) {
+                  if (error.getRegion().isOnCallable()) {
                     return methodDeclarationTree.findNode(error.encMember(), error.encClass());
                   }
                   // For methods invoked in an initialization region, where the error is that
@@ -300,8 +302,8 @@ public class Annotator {
             .filter(
                 fix ->
                     fix.isOnField()
-                        && (fix.reasons.contains("METHOD_NO_INIT")
-                            || fix.reasons.contains("FIELD_NO_INIT")))
+                        && (fix.reasons.contains("FIELD_NO_INIT")
+                            || fix.reasons.contains("METHOD_NO_INIT")))
             // Filter nodes annotated with SuppressWarnings("NullAway")
             .filter(fix -> !fieldsWithSuppressWarnings.contains(fix.toField()))
             .map(

--- a/annotator-core/src/main/java/edu/ucr/cs/riple/core/Annotator.java
+++ b/annotator-core/src/main/java/edu/ucr/cs/riple/core/Annotator.java
@@ -240,7 +240,7 @@ public class Annotator {
             // find the corresponding method nodes.
             .map(
                 error -> {
-                  if (error.getRegion().isOnMethod()) {
+                  if (error.getRegion().isOnCallable()) {
                     return methodDeclarationTree.findNode(error.encMember(), error.encClass());
                   }
                   // For methods invoked in an initialization region, where the error is that

--- a/annotator-core/src/main/java/edu/ucr/cs/riple/core/metadata/index/Error.java
+++ b/annotator-core/src/main/java/edu/ucr/cs/riple/core/metadata/index/Error.java
@@ -55,6 +55,8 @@ public class Error {
   protected final Region region;
   /** Error type for method initialization errors from NullAway in {@code String}. */
   public static final String METHOD_INITIALIZER_ERROR = "METHOD_NO_INIT";
+  /** Error type for field initialization errors from NullAway in {@code String}. */
+  public static final String FIELD_INITIALIZER_ERROR = "FIELD_NO_INIT";
 
   public Error(
       String messageType,
@@ -248,5 +250,16 @@ public class Error {
               key.change, ImmutableSet.copyOf(fixReasonsMap.get(key)), key.fixSourceIsInTarget));
     }
     return builder.build();
+  }
+
+  /**
+   * Returns true if the error is an initialization error ({@code METHOD_NO_INIT} or {@code
+   * FIELD_NO_INIT}).
+   *
+   * @return true, if the error is an initialization error.
+   */
+  public boolean isInitializationError() {
+    return this.messageType.equals(METHOD_INITIALIZER_ERROR)
+        || this.messageType.equals(FIELD_INITIALIZER_ERROR);
   }
 }

--- a/annotator-core/src/main/java/edu/ucr/cs/riple/core/metadata/trackers/Region.java
+++ b/annotator-core/src/main/java/edu/ucr/cs/riple/core/metadata/trackers/Region.java
@@ -24,6 +24,7 @@
 
 package edu.ucr.cs.riple.core.metadata.trackers;
 
+import edu.ucr.cs.riple.injector.Helper;
 import edu.ucr.cs.riple.scanner.generatedcode.SourceType;
 import java.util.Objects;
 
@@ -58,7 +59,7 @@ public class Region {
   public Region(String encClass, String encMember, SourceType sourceType) {
     this.clazz = encClass == null ? "null" : encClass;
     this.member = encMember == null ? "null" : encMember;
-    this.type = getType(member);
+    this.type = getType(encClass, member);
     this.sourceType = sourceType;
   }
 
@@ -67,17 +68,19 @@ public class Region {
   }
 
   /**
-   * Initializes {@link Region#type} based on the string representation of member.
+   * Initializes {@link Region#type} based on the string representation of regionMember.
    *
-   * @param member Symbol of the region representative.
+   * @param regionMember Symbol of the region representative.
    * @return The corresponding Type.
    */
-  public static Type getType(String member) {
-    if (member.equals("null")) {
+  public static Type getType(String regionClass, String regionMember) {
+    if (regionMember.equals("null")) {
       return Type.STATIC_BLOCK;
     }
-    if (member.contains("(")) {
-      return Type.METHOD;
+    if (regionMember.contains("(")) {
+      return Helper.extractCallableName(regionMember).equals(Helper.simpleName(regionClass))
+          ? Type.CONSTRUCTOR
+          : Type.METHOD;
     }
     return Type.FIELD;
   }

--- a/annotator-core/src/main/java/edu/ucr/cs/riple/core/metadata/trackers/Region.java
+++ b/annotator-core/src/main/java/edu/ucr/cs/riple/core/metadata/trackers/Region.java
@@ -51,6 +51,7 @@ public class Region {
   public enum Type {
     METHOD,
     FIELD,
+    CONSTRUCTOR,
     STATIC_BLOCK
   }
 
@@ -88,6 +89,24 @@ public class Region {
    */
   public boolean isOnMethod() {
     return type.equals(Type.METHOD);
+  }
+
+  /**
+   * Checks if region targets a constructor body.
+   *
+   * @return true, if region is targeting a constructor body.
+   */
+  public boolean isOnConstructor() {
+    return type.equals(Type.CONSTRUCTOR);
+  }
+
+  /**
+   * Checks if region targets a method or constructor body.
+   *
+   * @return true, if region is targeting a method or constructor body.
+   */
+  public boolean isOnCallable() {
+    return isOnConstructor() || isOnMethod();
   }
 
   /**

--- a/annotator-core/src/test/java/edu/ucr/cs/riple/core/CoreTest.java
+++ b/annotator-core/src/test/java/edu/ucr/cs/riple/core/CoreTest.java
@@ -160,10 +160,15 @@ public class CoreTest extends BaseCoreTest {
         .addInputLines(
             "Main.java",
             "package test;",
+            "import javax.annotation.Nullable;",
             "public class Main {",
             "   Object f;",
             "   Main(Object f) {",
             "     this.f = f;",
+            "   }",
+            "   Main(Object f, @Nullable Object o) {",
+            "     this.f = f;",
+            "     Integer h = o.hashCode();",
             "   }",
             "}",
             "class C {",
@@ -174,6 +179,16 @@ public class CoreTest extends BaseCoreTest {
             new TReport(new OnParameter("Main.java", "test.Main", "Main(java.lang.Object)", 0), 1))
         .enableForceResolve()
         .start();
+    List<AddAnnotation> expectedAnnotations =
+        List.of(
+            new AddMarkerAnnotation(
+                new OnMethod("Main.java", "test.Main", "Main(java.lang.Object)"),
+                "org.jspecify.nullness.NullUnmarked"),
+            new AddMarkerAnnotation(
+                new OnMethod("Main.java", "test.Main", "Main(java.lang.Object,java.lang.Object)"),
+                "org.jspecify.nullness.NullUnmarked"));
+    Assert.assertEquals(
+        expectedAnnotations, coreTestHelper.getConfig().log.getInjectedAnnotations());
   }
 
   @Test


### PR DESCRIPTION
This PR fixes a bug which was causing annotator to only inject `@NullUnmarked` annotations on methods. This PR fixes this issue and enables Annotator to add `@NullUnmarked` annotation for errors enclosed by constructors.