### PR TITLE
Rename TrackerNode to ImpactedRegion and document

### DIFF
--- a/annotator-scanner/src/main/java/edu/ucr/cs/riple/scanner/AnnotatorScanner.java
+++ b/annotator-scanner/src/main/java/edu/ucr/cs/riple/scanner/AnnotatorScanner.java
@@ -41,8 +41,8 @@ import com.sun.source.tree.MethodTree;
 import com.sun.source.tree.VariableTree;
 import com.sun.tools.javac.code.Symbol;
 import edu.ucr.cs.riple.scanner.out.ClassInfo;
-import edu.ucr.cs.riple.scanner.out.MethodInfo;
 import edu.ucr.cs.riple.scanner.out.ImpactedRegion;
+import edu.ucr.cs.riple.scanner.out.MethodInfo;
 import java.util.ArrayList;
 import java.util.List;
 import javax.lang.model.element.ElementKind;
@@ -162,7 +162,8 @@ public class AnnotatorScanner extends BugChecker
       context
           .getConfig()
           .getSerializer()
-          .serializeFieldGraphNode(new ImpactedRegion(context.getConfig(), symbol, state.getPath()));
+          .serializeFieldGraphNode(
+              new ImpactedRegion(context.getConfig(), symbol, state.getPath()));
     }
   }
 }

--- a/annotator-scanner/src/main/java/edu/ucr/cs/riple/scanner/AnnotatorScanner.java
+++ b/annotator-scanner/src/main/java/edu/ucr/cs/riple/scanner/AnnotatorScanner.java
@@ -42,7 +42,7 @@ import com.sun.source.tree.VariableTree;
 import com.sun.tools.javac.code.Symbol;
 import edu.ucr.cs.riple.scanner.out.ClassInfo;
 import edu.ucr.cs.riple.scanner.out.MethodInfo;
-import edu.ucr.cs.riple.scanner.out.TrackerNode;
+import edu.ucr.cs.riple.scanner.out.ImpactedRegion;
 import java.util.ArrayList;
 import java.util.List;
 import javax.lang.model.element.ElementKind;
@@ -100,7 +100,7 @@ public class AnnotatorScanner extends BugChecker
     config
         .getSerializer()
         .serializeCallGraphNode(
-            new TrackerNode(config, ASTHelpers.getSymbol(tree), state.getPath()));
+            new ImpactedRegion(config, ASTHelpers.getSymbol(tree), state.getPath()));
     return Description.NO_MATCH;
   }
 
@@ -162,7 +162,7 @@ public class AnnotatorScanner extends BugChecker
       context
           .getConfig()
           .getSerializer()
-          .serializeFieldGraphNode(new TrackerNode(context.getConfig(), symbol, state.getPath()));
+          .serializeFieldGraphNode(new ImpactedRegion(context.getConfig(), symbol, state.getPath()));
     }
   }
 }

--- a/annotator-scanner/src/main/java/edu/ucr/cs/riple/scanner/Serializer.java
+++ b/annotator-scanner/src/main/java/edu/ucr/cs/riple/scanner/Serializer.java
@@ -25,8 +25,8 @@
 package edu.ucr.cs.riple.scanner;
 
 import edu.ucr.cs.riple.scanner.out.ClassInfo;
-import edu.ucr.cs.riple.scanner.out.MethodInfo;
 import edu.ucr.cs.riple.scanner.out.ImpactedRegion;
+import edu.ucr.cs.riple.scanner.out.MethodInfo;
 import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.OutputStream;

--- a/annotator-scanner/src/main/java/edu/ucr/cs/riple/scanner/Serializer.java
+++ b/annotator-scanner/src/main/java/edu/ucr/cs/riple/scanner/Serializer.java
@@ -26,7 +26,7 @@ package edu.ucr.cs.riple.scanner;
 
 import edu.ucr.cs.riple.scanner.out.ClassInfo;
 import edu.ucr.cs.riple.scanner.out.MethodInfo;
-import edu.ucr.cs.riple.scanner.out.TrackerNode;
+import edu.ucr.cs.riple.scanner.out.ImpactedRegion;
 import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.OutputStream;
@@ -68,20 +68,20 @@ public class Serializer {
   }
 
   /**
-   * Appends the string representation of the {@link TrackerNode} corresponding to a call graph.
+   * Appends the string representation of the {@link ImpactedRegion} corresponding to a call graph.
    *
    * @param callGraphNode TrackerNode instance.
    */
-  public void serializeCallGraphNode(TrackerNode callGraphNode) {
+  public void serializeCallGraphNode(ImpactedRegion callGraphNode) {
     appendToFile(callGraphNode.toString(), this.callGraphPath);
   }
 
   /**
-   * Appends the string representation of the {@link TrackerNode} corresponding to a field graph.
+   * Appends the string representation of the {@link ImpactedRegion} corresponding to a field graph.
    *
    * @param fieldGraphNode TrackerNode instance.
    */
-  public void serializeFieldGraphNode(TrackerNode fieldGraphNode) {
+  public void serializeFieldGraphNode(ImpactedRegion fieldGraphNode) {
     appendToFile(fieldGraphNode.toString(), this.fieldGraphPath);
   }
 
@@ -125,10 +125,10 @@ public class Serializer {
     try {
       Files.createDirectories(config.getOutputDirectory());
       if (config.callTrackerIsActive()) {
-        initializeFile(callGraphPath, TrackerNode.header());
+        initializeFile(callGraphPath, ImpactedRegion.header());
       }
       if (config.fieldTrackerIsActive()) {
-        initializeFile(fieldGraphPath, TrackerNode.header());
+        initializeFile(fieldGraphPath, ImpactedRegion.header());
       }
       if (config.methodTrackerIsActive()) {
         initializeFile(methodInfoPath, MethodInfo.header());

--- a/annotator-scanner/src/main/java/edu/ucr/cs/riple/scanner/out/ImpactedRegion.java
+++ b/annotator-scanner/src/main/java/edu/ucr/cs/riple/scanner/out/ImpactedRegion.java
@@ -33,20 +33,27 @@ import edu.ucr.cs.riple.scanner.SymbolUtil;
 import edu.ucr.cs.riple.scanner.generatedcode.SourceType;
 import javax.annotation.Nullable;
 
-/** Container class for storing regions where a node has been used. */
-public class TrackerNode {
+/** Represents an impacted region for some class member (a field or a method). */
+public class ImpactedRegion {
 
-  /** Symbol of the used node. */
-  private final Symbol usedNode;
-  /** Symbol of the enclosing class of the region. */
+  /** Symbol of the member. */
+  private final Symbol memberSymbol;
+  /** Symbol of the enclosing class of the impacted region. */
   @Nullable private final Symbol.ClassSymbol regionClass;
-  /** Symbol of the region. */
+  /** Symbol of the impacted region. */
   @Nullable private final Symbol regionMember;
-  /** Source type of the region. */
+  /** Source type of the impacted region. */
   private final SourceType source;
 
-  public TrackerNode(Config config, Symbol usedNode, TreePath path) {
-    this.usedNode = usedNode;
+  /**
+   * Construct an ImpactedRegion
+   * @param config scanner configuration
+   * @param memberSymbol symbol for the class member
+   * @param path path to the AST node that uses or overrides the member; the impacted region information is computed
+   *             from the leaf of this path
+   */
+  public ImpactedRegion(Config config, Symbol memberSymbol, TreePath path) {
+    this.memberSymbol = memberSymbol;
     ClassTree enclosingClass =
         path.getLeaf() instanceof ClassTree
             ? (ClassTree) path.getLeaf()
@@ -66,12 +73,12 @@ public class TrackerNode {
     if (regionClass == null) {
       return "";
     }
-    Symbol enclosingClass = usedNode.enclClass();
+    Symbol enclosingClass = memberSymbol.enclClass();
     return String.join(
         "\t",
         regionClass.flatName(),
         ((regionMember == null) ? "null" : regionMember.toString()),
-        usedNode.toString(),
+        memberSymbol.toString(),
         ((enclosingClass == null) ? "null" : enclosingClass.flatName()),
         source.name());
   }

--- a/annotator-scanner/src/main/java/edu/ucr/cs/riple/scanner/out/ImpactedRegion.java
+++ b/annotator-scanner/src/main/java/edu/ucr/cs/riple/scanner/out/ImpactedRegion.java
@@ -47,10 +47,11 @@ public class ImpactedRegion {
 
   /**
    * Construct an ImpactedRegion
+   *
    * @param config scanner configuration
    * @param memberSymbol symbol for the class member
-   * @param path path to the AST node that uses or overrides the member; the impacted region information is computed
-   *             from the leaf of this path
+   * @param path path to the AST node that uses or overrides the member; the impacted region
+   *     information is computed from the leaf of this path
    */
   public ImpactedRegion(Config config, Symbol memberSymbol, TreePath path) {
     this.memberSymbol = memberSymbol;


### PR DESCRIPTION
I found #132 a bit hard to understand because I couldn't understand what exactly `TrackerNode` was for.  Here I renamed it to `ImpactedRegion` and added some documentation, which I think is helpful.  There should be no functional change here.