### PR TITLE
Resolves Flaky CI

### DIFF
--- a/annotator-core/src/test/java/edu/ucr/cs/riple/core/CoreTest.java
+++ b/annotator-core/src/test/java/edu/ucr/cs/riple/core/CoreTest.java
@@ -179,8 +179,8 @@ public class CoreTest extends BaseCoreTest {
             new TReport(new OnParameter("Main.java", "test.Main", "Main(java.lang.Object)", 0), 1))
         .enableForceResolve()
         .start();
-    List<AddAnnotation> expectedAnnotations =
-        List.of(
+    Set<AddAnnotation> expectedAnnotations =
+        Set.of(
             new AddMarkerAnnotation(
                 new OnMethod("Main.java", "test.Main", "Main(java.lang.Object)"),
                 "org.jspecify.nullness.NullUnmarked"),
@@ -188,7 +188,7 @@ public class CoreTest extends BaseCoreTest {
                 new OnMethod("Main.java", "test.Main", "Main(java.lang.Object,java.lang.Object)"),
                 "org.jspecify.nullness.NullUnmarked"));
     Assert.assertEquals(
-        expectedAnnotations, coreTestHelper.getConfig().log.getInjectedAnnotations());
+        expectedAnnotations, Set.copyOf(coreTestHelper.getConfig().log.getInjectedAnnotations()));
   }
 
   @Test


### PR DESCRIPTION
This PR resolves flaky CI. For test `fieldAssignNullableConstructorForceResolveEnabled` expected annotations were stored in a list and getting compared with the actual injected annotations. This caused CI fail for some runs. This PR updates the list  expected annotation to set for that specific test. Since this PR is a very small change and straightforward, I am going to land this once the CI pass to have a stable CI for other PRs. Please let me know if you would like to discuss this more and I will bring this back. Thank you.