### PR TITLE
Update scanner for serializing constructors calls

### DIFF
--- a/annotator-scanner/src/main/java/edu/ucr/cs/riple/scanner/AnnotatorScanner.java
+++ b/annotator-scanner/src/main/java/edu/ucr/cs/riple/scanner/AnnotatorScanner.java
@@ -38,6 +38,7 @@ import com.sun.source.tree.IdentifierTree;
 import com.sun.source.tree.MemberSelectTree;
 import com.sun.source.tree.MethodInvocationTree;
 import com.sun.source.tree.MethodTree;
+import com.sun.source.tree.NewClassTree;
 import com.sun.source.tree.VariableTree;
 import com.sun.tools.javac.code.Symbol;
 import edu.ucr.cs.riple.scanner.out.ClassInfo;
@@ -61,7 +62,8 @@ public class AnnotatorScanner extends BugChecker
         BugChecker.MethodTreeMatcher,
         BugChecker.IdentifierTreeMatcher,
         BugChecker.VariableTreeMatcher,
-        BugChecker.ClassTreeMatcher {
+        BugChecker.ClassTreeMatcher,
+        BugChecker.NewClassTreeMatcher {
 
   /**
    * Scanner context to store the state of the checker. Could not use {@link VisitorState#context}
@@ -101,6 +103,19 @@ public class AnnotatorScanner extends BugChecker
         .getSerializer()
         .serializeCallGraphNode(
             new ImpactedRegion(config, ASTHelpers.getSymbol(tree), state.getPath()));
+    return Description.NO_MATCH;
+  }
+
+  @Override
+  public Description matchNewClass(NewClassTree newClassTree, VisitorState state) {
+    Config config = context.getConfig();
+    if (!config.callTrackerIsActive()) {
+      return Description.NO_MATCH;
+    }
+    config
+        .getSerializer()
+        .serializeCallGraphNode(
+            new ImpactedRegion(config, ASTHelpers.getSymbol(newClassTree), state.getPath()));
     return Description.NO_MATCH;
   }
 

--- a/annotator-scanner/src/test/java/edu/ucr/cs/riple/scanner/MethodCallTrackerTest.java
+++ b/annotator-scanner/src/test/java/edu/ucr/cs/riple/scanner/MethodCallTrackerTest.java
@@ -75,7 +75,31 @@ public class MethodCallTrackerTest extends AnnotatorScannerBaseTest<TrackerNodeD
   }
 
   @Test
-  public void fieldDeclaredRegionComputationAllCases() {
+  public void callableTests() {
+    tester
+        .addSourceLines(
+            "edu/ucr/A.java",
+            "package edu.ucr;",
+            "public class A {",
+            "   A a = new A();",
+            "   A b = new A(0);",
+            "   A() { }",
+            "   A(int i) { }",
+            "   void bar() {",
+            "       A a = new A();",
+            "   }",
+            "}")
+        .setExpectedOutputs(
+            new TrackerNodeDisplay("edu.ucr.A", "a", "edu.ucr.A", "A()"),
+            new TrackerNodeDisplay("edu.ucr.A", "b", "edu.ucr.A", "A(int)"),
+            new TrackerNodeDisplay("edu.ucr.A", "bar()", "edu.ucr.A", "A()"),
+            new TrackerNodeDisplay("edu.ucr.A", "A()", "java.lang.Object", "Object()"),
+            new TrackerNodeDisplay("edu.ucr.A", "A(int)", "java.lang.Object", "Object()"))
+        .doTest();
+  }
+
+  @Test
+  public void fieldDeclaredRegionComputationAllCasesCallables() {
     tester
         .addSourceLines(
             "edu/ucr/A.java",


### PR DESCRIPTION
This PR updates scanner to serialize constructor calls. It has an identical logic for serializing `methods` calls. Constructor calls will not be visited by `matchMethodInvocation` and are only visited by `matchNewClass` method. This PR simply adds `matchNewClass` method and the corresponding logic.