### PR TITLE
Rename FieldInitializationAnalysis to FieldInitializationStore

### DIFF
--- a/annotator-core/src/main/java/edu/ucr/cs/riple/core/Annotator.java
+++ b/annotator-core/src/main/java/edu/ucr/cs/riple/core/Annotator.java
@@ -109,10 +109,7 @@ public class Annotator {
     config.initializeAdapter(fieldDeclarationStore, nonnullStore);
     Set<OnField> uninitializedFields =
         Utility.readFixesFromOutputDirectory(config, fieldDeclarationStore).stream()
-            .filter(
-                fix ->
-                    fix.isOnField() && fix.reasons.contains("FIELD_NO_INIT")
-                        || fix.reasons.contains("METHOD_NO_INIT"))
+            .filter(fix -> fix.isOnField() && fix.reasons.contains("FIELD_NO_INIT"))
             .map(Fix::toField)
             .collect(Collectors.toSet());
     fieldInitializationStore = new FieldInitializationStore(config);

--- a/annotator-core/src/main/java/edu/ucr/cs/riple/core/metadata/field/FieldInitializationStore.java
+++ b/annotator-core/src/main/java/edu/ucr/cs/riple/core/metadata/field/FieldInitializationStore.java
@@ -13,13 +13,13 @@ import java.util.HashSet;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
-import java.util.stream.Stream;
+import java.util.stream.Collectors;
 
 /**
  * Detects initializer methods in source code. Reads field initialization info serialized by
  * NullAway and uses a heuristic to detect them.
  */
-public class FieldInitializationAnalysis extends MetaData<FieldInitializationNode> {
+public class FieldInitializationStore extends MetaData<FieldInitializationNode> {
 
   /**
    * Output file name. It contains information about initializations of fields via methods. On each
@@ -30,12 +30,12 @@ public class FieldInitializationAnalysis extends MetaData<FieldInitializationNod
   public static final String FILE_NAME = "field_init.tsv";
 
   /**
-   * Constructs an {@link FieldInitializationAnalysis} instance. After this call, all serialized
+   * Constructs an {@link FieldInitializationStore} instance. After this call, all serialized
    * information from NullAway has been processed.
    *
    * @param config Annotator config.
    */
-  public FieldInitializationAnalysis(Config config) {
+  public FieldInitializationStore(Config config) {
     super(config, config.target.dir.resolve(FILE_NAME));
   }
 
@@ -63,7 +63,7 @@ public class FieldInitializationAnalysis extends MetaData<FieldInitializationNod
    * @param uninitializedFields Set of uninitialized fields.
    * @return Location of initializers.
    */
-  public Stream<OnMethod> findInitializers(Set<OnField> uninitializedFields) {
+  public Set<OnMethod> findInitializers(Set<OnField> uninitializedFields) {
     // Set does not have a get() method, instead we use map here which can find the element
     // efficiently.
     Map<String, Class> classes = new HashMap<>();
@@ -80,7 +80,10 @@ public class FieldInitializationAnalysis extends MetaData<FieldInitializationNod
                       classes.putIfAbsent(clazz.clazz, clazz);
                       classes.get(clazz.clazz).visit(node);
                     }));
-    return classes.values().stream().map(Class::findInitializer).filter(Objects::nonNull);
+    return classes.values().stream()
+        .map(Class::findInitializer)
+        .filter(Objects::nonNull)
+        .collect(Collectors.toSet());
   }
 
   /** Stores class field / method initialization status. */

--- a/injector/src/main/java/edu/ucr/cs/riple/injector/location/Location.java
+++ b/injector/src/main/java/edu/ucr/cs/riple/injector/location/Location.java
@@ -197,4 +197,13 @@ public abstract class Location {
   public int hashCode() {
     return Objects.hash(type, clazz);
   }
+
+  /**
+   * Returns the fully qualified class name of the target element.
+   *
+   * @return Fully qualified class name of the target element.
+   */
+  public String getClazz() {
+    return clazz;
+  }
 }


### PR DESCRIPTION
This PR renames `FieldInitializationAnalysis` to `FieldInitializationStore` along minor refactoring for return value of `findInitializers()` to Set rather a Stream. It also prepares the codebase for the upcoming PR.