### PR TITLE
Rename tree to methodDeclarationTree in fields to resolve ambiguity.

### DIFF
--- a/annotator-core/src/main/java/edu/ucr/cs/riple/core/metadata/trackers/CompoundTracker.java
+++ b/annotator-core/src/main/java/edu/ucr/cs/riple/core/metadata/trackers/CompoundTracker.java
@@ -44,8 +44,10 @@ public class CompoundTracker implements RegionTracker {
 
   private final ImmutableSet<GeneratedRegionTracker> generatedRegionsTrackers;
 
-  public CompoundTracker(Config config, ModuleInfo info, MethodDeclarationTree methodDeclarationTree) {
-    MethodRegionTracker methodRegionTracker = new MethodRegionTracker(config, info, methodDeclarationTree);
+  public CompoundTracker(
+      Config config, ModuleInfo info, MethodDeclarationTree methodDeclarationTree) {
+    MethodRegionTracker methodRegionTracker =
+        new MethodRegionTracker(config, info, methodDeclarationTree);
     this.trackers =
         ImmutableSet.of(
             new FieldRegionTracker(config, info),
@@ -54,7 +56,8 @@ public class CompoundTracker implements RegionTracker {
     ImmutableSet.Builder<GeneratedRegionTracker> generatedRegionTrackerBuilder =
         new ImmutableSet.Builder<>();
     if (config.generatedCodeDetectors.contains(SourceType.LOMBOK)) {
-      generatedRegionTrackerBuilder.add(new LombokTracker(methodDeclarationTree, methodRegionTracker));
+      generatedRegionTrackerBuilder.add(
+          new LombokTracker(methodDeclarationTree, methodRegionTracker));
     }
     this.generatedRegionsTrackers = generatedRegionTrackerBuilder.build();
   }

--- a/annotator-core/src/main/java/edu/ucr/cs/riple/core/metadata/trackers/CompoundTracker.java
+++ b/annotator-core/src/main/java/edu/ucr/cs/riple/core/metadata/trackers/CompoundTracker.java
@@ -44,17 +44,17 @@ public class CompoundTracker implements RegionTracker {
 
   private final ImmutableSet<GeneratedRegionTracker> generatedRegionsTrackers;
 
-  public CompoundTracker(Config config, ModuleInfo info, MethodDeclarationTree tree) {
-    MethodRegionTracker methodRegionTracker = new MethodRegionTracker(config, info, tree);
+  public CompoundTracker(Config config, ModuleInfo info, MethodDeclarationTree methodDeclarationTree) {
+    MethodRegionTracker methodRegionTracker = new MethodRegionTracker(config, info, methodDeclarationTree);
     this.trackers =
         ImmutableSet.of(
             new FieldRegionTracker(config, info),
             methodRegionTracker,
-            new ParameterRegionTracker(tree, methodRegionTracker));
+            new ParameterRegionTracker(methodDeclarationTree, methodRegionTracker));
     ImmutableSet.Builder<GeneratedRegionTracker> generatedRegionTrackerBuilder =
         new ImmutableSet.Builder<>();
     if (config.generatedCodeDetectors.contains(SourceType.LOMBOK)) {
-      generatedRegionTrackerBuilder.add(new LombokTracker(tree, methodRegionTracker));
+      generatedRegionTrackerBuilder.add(new LombokTracker(methodDeclarationTree, methodRegionTracker));
     }
     this.generatedRegionsTrackers = generatedRegionTrackerBuilder.build();
   }

--- a/annotator-core/src/main/java/edu/ucr/cs/riple/core/metadata/trackers/FieldRegionTracker.java
+++ b/annotator-core/src/main/java/edu/ucr/cs/riple/core/metadata/trackers/FieldRegionTracker.java
@@ -24,7 +24,6 @@
 
 package edu.ucr.cs.riple.core.metadata.trackers;
 
-import com.google.common.collect.ImmutableSet;
 import edu.ucr.cs.riple.core.Config;
 import edu.ucr.cs.riple.core.ModuleInfo;
 import edu.ucr.cs.riple.core.metadata.MetaData;
@@ -40,14 +39,6 @@ public class FieldRegionTracker extends MetaData<TrackerNode> implements RegionT
 
   public FieldRegionTracker(Config config, ModuleInfo info) {
     super(config, info.dir.resolve(Serializer.FIELD_GRAPH_FILE_NAME));
-  }
-
-  public FieldRegionTracker(Config config, ImmutableSet<ModuleInfo> modules) {
-    super(
-        config,
-        modules.stream()
-            .map(info -> info.dir.resolve(Serializer.FIELD_GRAPH_FILE_NAME))
-            .collect(ImmutableSet.toImmutableSet()));
   }
 
   @Override

--- a/annotator-core/src/main/java/edu/ucr/cs/riple/core/metadata/trackers/MethodRegionTracker.java
+++ b/annotator-core/src/main/java/edu/ucr/cs/riple/core/metadata/trackers/MethodRegionTracker.java
@@ -44,21 +44,24 @@ public class MethodRegionTracker extends MetaData<TrackerNode> implements Region
    * {@link MethodDeclarationTree} instance, used to retrieve regions that will be affected due to
    * inheritance violations.
    */
-  private final MethodDeclarationTree tree;
+  private final MethodDeclarationTree methodDeclarationTree;
 
-  public MethodRegionTracker(Config config, ModuleInfo info, MethodDeclarationTree tree) {
+  public MethodRegionTracker(
+      Config config, ModuleInfo info, MethodDeclarationTree methodDeclarationTree) {
     super(config, info.dir.resolve(Serializer.METHOD_IMPACTED_REGION_FILE_NAME));
-    this.tree = tree;
+    this.methodDeclarationTree = methodDeclarationTree;
   }
 
   public MethodRegionTracker(
-      Config config, ImmutableSet<ModuleInfo> modules, MethodDeclarationTree tree) {
+      Config config,
+      ImmutableSet<ModuleInfo> modules,
+      MethodDeclarationTree methodDeclarationTree) {
     super(
         config,
         modules.stream()
             .map(info -> info.dir.resolve(Serializer.METHOD_IMPACTED_REGION_FILE_NAME))
             .collect(ImmutableSet.toImmutableSet()));
-    this.tree = tree;
+    this.methodDeclarationTree = methodDeclarationTree;
   }
 
   @Override
@@ -77,7 +80,8 @@ public class MethodRegionTracker extends MetaData<TrackerNode> implements Region
     // Add method itself.
     regions.add(new Region(onMethod.clazz, onMethod.method));
     // Add immediate super method.
-    MethodNode parent = tree.getClosestSuperMethod(onMethod.method, onMethod.clazz);
+    MethodNode parent =
+        methodDeclarationTree.getClosestSuperMethod(onMethod.method, onMethod.clazz);
     if (parent != null && parent.isNonTop()) {
       regions.add(new Region(parent.location.clazz, parent.location.method));
     }

--- a/annotator-core/src/main/java/edu/ucr/cs/riple/core/metadata/trackers/ParameterRegionTracker.java
+++ b/annotator-core/src/main/java/edu/ucr/cs/riple/core/metadata/trackers/ParameterRegionTracker.java
@@ -38,14 +38,14 @@ public class ParameterRegionTracker implements RegionTracker {
    * {@link MethodDeclarationTree} instance, used to retrieve regions that will be affected due to
    * inheritance violations.
    */
-  private final MethodDeclarationTree tree;
+  private final MethodDeclarationTree methodDeclarationTree;
 
   /** {@link MethodRegionTracker} instance, used to retrieve all sites. */
   private final MethodRegionTracker methodRegionTracker;
 
   public ParameterRegionTracker(
-      MethodDeclarationTree tree, MethodRegionTracker methodRegionTracker) {
-    this.tree = tree;
+      MethodDeclarationTree methodDeclarationTree, MethodRegionTracker methodRegionTracker) {
+    this.methodDeclarationTree = methodDeclarationTree;
     this.methodRegionTracker = methodRegionTracker;
   }
 
@@ -57,7 +57,7 @@ public class ParameterRegionTracker implements RegionTracker {
     OnParameter parameter = location.toParameter();
     // Get regions which will be potentially affected by inheritance violations.
     Set<Region> regions =
-        tree.getSubMethods(parameter.method, parameter.clazz, false).stream()
+        methodDeclarationTree.getSubMethods(parameter.method, parameter.clazz, false).stream()
             .map(node -> new Region(node.location.clazz, node.location.method))
             .collect(Collectors.toSet());
     // Add the method the fix is targeting.


### PR DESCRIPTION
This PR simply renames some field or local variables to `methodDeclarationTree` rather than the ambiguous name `tree`.