### PR TITLE
Update NullAway test version to 0.10.10

### DIFF
--- a/annotator-core/build.gradle
+++ b/annotator-core/build.gradle
@@ -50,7 +50,7 @@ dependencies {
 }
 
 // Should be the latest supporting version of NullAway.
-def NULLAWAY_TEST = "0.10.10-SNAPSHOT"
+def NULLAWAY_TEST = "0.10.10"
 
 tasks.test.dependsOn(':annotator-scanner:publishToMavenLocal')
 tasks.test.dependsOn(':qual:publishToMavenLocal')

--- a/annotator-core/build.gradle
+++ b/annotator-core/build.gradle
@@ -50,7 +50,7 @@ dependencies {
 }
 
 // Should be the latest supporting version of NullAway.
-def NULLAWAY_TEST = "0.10.8"
+def NULLAWAY_TEST = "0.10.10-SNAPSHOT"
 
 tasks.test.dependsOn(':annotator-scanner:publishToMavenLocal')
 tasks.test.dependsOn(':qual:publishToMavenLocal')

--- a/annotator-core/src/main/java/edu/ucr/cs/riple/core/Config.java
+++ b/annotator-core/src/main/java/edu/ucr/cs/riple/core/Config.java
@@ -27,7 +27,7 @@ package edu.ucr.cs.riple.core;
 import com.google.common.base.Preconditions;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Sets;
-import edu.ucr.cs.riple.core.adapters.NullAwayV2Adapter;
+import edu.ucr.cs.riple.core.adapters.NullAwayV3Adapter;
 import edu.ucr.cs.riple.core.adapters.NullAwayVersionAdapter;
 import edu.ucr.cs.riple.core.log.Log;
 import edu.ucr.cs.riple.core.metadata.field.FieldDeclarationStore;
@@ -589,7 +589,10 @@ public class Config {
           throw new RuntimeException(
               "This annotator version does not support serialization version 1, please upgrade NullAway to 0.10.6+ (with SerializeFixMetadataVersion=2) or use version 1.3.5 of Annotator.");
         case 2:
-          this.adapter = new NullAwayV2Adapter(this, fieldDeclarationStore, nonnullStore);
+          throw new RuntimeException(
+              "This annotator version does not support serialization version 2, please upgrade NullAway to 0.10.10+. Serialization version v2 is skipped and was used for an alpha version of the Annotator.");
+        case 3:
+          this.adapter = new NullAwayV3Adapter(this, fieldDeclarationStore, nonnullStore);
           this.offsetHandlingIsActivated = true;
           break;
         default:

--- a/annotator-core/src/main/java/edu/ucr/cs/riple/core/adapters/NullAwayV3Adapter.java
+++ b/annotator-core/src/main/java/edu/ucr/cs/riple/core/adapters/NullAwayV3Adapter.java
@@ -1,3 +1,27 @@
+/*
+ * MIT License
+ *
+ * Copyright (c) 2023 Nima Karimipour
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
 package edu.ucr.cs.riple.core.adapters;
 
 import com.google.common.base.Preconditions;
@@ -16,9 +40,22 @@ import java.util.Arrays;
 import java.util.Set;
 import java.util.stream.Collectors;
 
-public class NullAwayV2Adapter extends NullAwayAdapterBaseClass {
+/**
+ * NullAway serialization adapter for version 3.
+ *
+ * <p>Updates to previous version (version 1):
+ *
+ * <ul>
+ *   <li>Serialized errors contain an extra column indicating the offset of the program point where
+ *       the error is reported.
+ *   <li>Serialized errors contain an extra column indicating the path to the containing source file
+ *       where the error is reported
+ *   <li>Type arguments and Type use annotations are excluded from the serialized method signatures.
+ * </ul>
+ */
+public class NullAwayV3Adapter extends NullAwayAdapterBaseClass {
 
-  public NullAwayV2Adapter(
+  public NullAwayV3Adapter(
       Config config, FieldDeclarationStore fieldDeclarationStore, NonnullStore nonnullStore) {
     super(config, fieldDeclarationStore, nonnullStore);
   }
@@ -27,7 +64,7 @@ public class NullAwayV2Adapter extends NullAwayAdapterBaseClass {
   public TrackerNode deserializeTrackerNode(String[] values) {
     Preconditions.checkArgument(
         values.length == 5,
-        "Expected 5 values to create TrackerNode instance in NullAway serialization version 1 but found: "
+        "Expected 5 values to create TrackerNode instance in NullAway serialization version 3 but found: "
             + values.length);
     return new TrackerNode(
         new Region(values[0], values[1], SourceType.valueOf(values[4])), values[2], values[3]);
@@ -62,6 +99,6 @@ public class NullAwayV2Adapter extends NullAwayAdapterBaseClass {
 
   @Override
   public int getVersionNumber() {
-    return 2;
+    return 3;
   }
 }

--- a/annotator-scanner/src/main/java/edu/ucr/cs/riple/scanner/AnnotatorScanner.java
+++ b/annotator-scanner/src/main/java/edu/ucr/cs/riple/scanner/AnnotatorScanner.java
@@ -115,6 +115,14 @@ public class AnnotatorScanner extends BugChecker
   @Override
   public Description matchNewClass(NewClassTree tree, VisitorState state) {
     Config config = context.getConfig();
+    Symbol.MethodSymbol methodSymbol = ASTHelpers.getSymbol(tree);
+    if (methodSymbol == null) {
+      throw new RuntimeException("not expecting unresolved method here");
+    }
+    if (methodSymbol.owner.enclClass().getSimpleName().isEmpty()) {
+      // An anonymous class cannot declare its own constructors, so we do not need to serialize it.
+      return Description.NO_MATCH;
+    }
     config
         .getSerializer()
         .serializeImpactedRegionForMethod(

--- a/annotator-scanner/src/main/java/edu/ucr/cs/riple/scanner/AnnotatorScanner.java
+++ b/annotator-scanner/src/main/java/edu/ucr/cs/riple/scanner/AnnotatorScanner.java
@@ -125,7 +125,7 @@ public class AnnotatorScanner extends BugChecker
     if (methodSymbol.owner.enclClass().getSimpleName().isEmpty()) {
       // An anonymous class cannot declare its own constructors, so we do not need to serialize it.
       return Description.NO_MATCH;
-    }  
+    }
     config
         .getSerializer()
         .serializeImpactedRegionForMethod(

--- a/annotator-scanner/src/main/java/edu/ucr/cs/riple/scanner/Serializer.java
+++ b/annotator-scanner/src/main/java/edu/ucr/cs/riple/scanner/Serializer.java
@@ -24,7 +24,11 @@
 
 package edu.ucr.cs.riple.scanner;
 
+import static java.util.stream.Collectors.joining;
+
 import com.sun.tools.javac.code.Symbol;
+import com.sun.tools.javac.code.Type;
+import com.sun.tools.javac.util.Name;
 import edu.ucr.cs.riple.scanner.location.SymbolLocation;
 import edu.ucr.cs.riple.scanner.out.ClassInfo;
 import edu.ucr.cs.riple.scanner.out.ImpactedRegion;
@@ -162,6 +166,69 @@ public class Serializer {
     } catch (IOException e) {
       throw new RuntimeException("Could not finish resetting serializer", e);
     }
+  }
+
+  /**
+   * Serializes the given {@link Symbol} to a string.
+   *
+   * @param symbol The symbol to serialize.
+   * @return The serialized symbol.
+   */
+  public static String serializeSymbol(@Nullable Symbol symbol) {
+    if (symbol == null) {
+      return "null";
+    }
+    switch (symbol.getKind()) {
+      case FIELD:
+      case PARAMETER:
+        return symbol.name.toString();
+      case METHOD:
+      case CONSTRUCTOR:
+        return serializeMethodSignature((Symbol.MethodSymbol) symbol);
+      default:
+        return symbol.flatName().toString();
+    }
+  }
+
+  /**
+   * Serializes the signature of the given {@link Symbol.MethodSymbol} to a string.
+   *
+   * @param methodSymbol The method symbol to serialize.
+   * @return The serialized method symbol.
+   */
+  private static String serializeMethodSignature(Symbol.MethodSymbol methodSymbol) {
+    StringBuilder sb = new StringBuilder();
+    if (methodSymbol.isConstructor()) {
+      // For constructors, method's simple name is <init> and not the enclosing class, need to
+      // locate the enclosing class.
+      Symbol.ClassSymbol encClass = methodSymbol.owner.enclClass();
+      Name name = encClass.getSimpleName();
+      if (name.isEmpty()) {
+        // An anonymous class cannot declare its own constructor. Based on this assumption and our
+        // use case, we should not serialize the method signature.
+        throw new RuntimeException(
+            "Did not expect method serialization for anonymous class constructor: "
+                + methodSymbol
+                + ", in anonymous class: "
+                + encClass);
+      }
+      sb.append(name);
+    } else {
+      // For methods, we use the name of the method.
+      sb.append(methodSymbol.getSimpleName());
+    }
+    sb.append(
+        methodSymbol.getParameters().stream()
+            .map(
+                parameter ->
+                    // check if array
+                    (parameter.type instanceof Type.ArrayType)
+                        // if is array, get the element type and append "[]"
+                        ? ((Type.ArrayType) parameter.type).elemtype.tsym + "[]"
+                        // else, just get the type
+                        : parameter.type.tsym.toString())
+            .collect(joining(",", "(", ")")));
+    return sb.toString();
   }
 
   /**

--- a/annotator-scanner/src/main/java/edu/ucr/cs/riple/scanner/out/ImpactedRegion.java
+++ b/annotator-scanner/src/main/java/edu/ucr/cs/riple/scanner/out/ImpactedRegion.java
@@ -29,6 +29,7 @@ import com.sun.source.tree.ClassTree;
 import com.sun.source.util.TreePath;
 import com.sun.tools.javac.code.Symbol;
 import edu.ucr.cs.riple.scanner.Config;
+import edu.ucr.cs.riple.scanner.Serializer;
 import edu.ucr.cs.riple.scanner.SymbolUtil;
 import edu.ucr.cs.riple.scanner.generatedcode.SourceType;
 import javax.annotation.Nullable;
@@ -77,10 +78,10 @@ public class ImpactedRegion {
     Symbol enclosingClass = memberSymbol.enclClass();
     return String.join(
         "\t",
-        regionClass.flatName(),
-        ((regionMember == null) ? "null" : regionMember.toString()),
-        memberSymbol.toString(),
-        ((enclosingClass == null) ? "null" : enclosingClass.flatName()),
+        Serializer.serializeSymbol(regionClass),
+        Serializer.serializeSymbol(regionMember),
+        Serializer.serializeSymbol(memberSymbol),
+        Serializer.serializeSymbol(enclosingClass),
         source.name());
   }
 

--- a/annotator-scanner/src/main/java/edu/ucr/cs/riple/scanner/out/MethodInfo.java
+++ b/annotator-scanner/src/main/java/edu/ucr/cs/riple/scanner/out/MethodInfo.java
@@ -132,7 +132,7 @@ public class MethodInfo {
         "\t",
         String.valueOf(id),
         (clazz != null ? clazz.flatName() : "null"),
-        symbol.toString(),
+        Serializer.serializeSymbol(symbol),
         String.valueOf(parentID),
         String.valueOf(symbol.getParameters().size()),
         Arrays.toString(parameterAnnotationFlags),

--- a/injector/src/test/java/edu/ucr/cs/riple/injector/BasicTest.java
+++ b/injector/src/test/java/edu/ucr/cs/riple/injector/BasicTest.java
@@ -88,10 +88,7 @@ public class BasicTest extends BaseInjectorTest {
             "}")
         .addChanges(
             new AddMarkerAnnotation(
-                new OnMethod(
-                    "Super.java",
-                    "com.uber.Super",
-                    "test(@javax.annotation.Nullable java.lang.Object)"),
+                new OnMethod("Super.java", "com.uber.Super", "test(java.lang.Object)"),
                 "javax.annotation.Nullable"))
         .start();
   }

--- a/injector/src/test/java/edu/ucr/cs/riple/injector/ComprehensiveTest.java
+++ b/injector/src/test/java/edu/ucr/cs/riple/injector/ComprehensiveTest.java
@@ -319,44 +319,27 @@ public class ComprehensiveTest extends BaseInjectorTest {
         .addChanges(
             new RemoveAnnotation(
                 new OnMethod(
-                    "Main.java",
-                    "edu.ucr.Main",
-                    "foo6(Map<String, Object>, Object, Object, Object, Object)"),
+                    "Main.java", "edu.ucr.Main", "foo6(Map, Object, Object, Object, Object)"),
                 "javax.annotation.Nullable"),
             new RemoveAnnotation(
                 new OnParameter(
-                    "Main.java",
-                    "edu.ucr.Main",
-                    "foo6(Map<String, Object>, Object, Object, Object, Object)",
-                    0),
+                    "Main.java", "edu.ucr.Main", "foo6(Map, Object, Object, Object, Object)", 0),
                 "javax.annotation.Nullable"),
             new AddMarkerAnnotation(
                 new OnParameter(
-                    "Main.java",
-                    "edu.ucr.Main",
-                    "foo6(Map<String, Object>, Object, Object, Object, Object)",
-                    1),
+                    "Main.java", "edu.ucr.Main", "foo6(Map, Object, Object, Object, Object)", 1),
                 "javax.annotation.Nullable"),
             new RemoveAnnotation(
                 new OnParameter(
-                    "Main.java",
-                    "edu.ucr.Main",
-                    "foo6(Map<String, Object>, Object, Object, Object, Object)",
-                    2),
+                    "Main.java", "edu.ucr.Main", "foo6(Map, Object, Object, Object, Object)", 2),
                 "javax.annotation.Nullable"),
             new AddMarkerAnnotation(
                 new OnParameter(
-                    "Main.java",
-                    "edu.ucr.Main",
-                    "foo6(Map<String, Object>, Object, Object, Object, Object)",
-                    3),
+                    "Main.java", "edu.ucr.Main", "foo6(Map, Object, Object, Object, Object)", 3),
                 "javax.annotation.Nullable"),
             new RemoveAnnotation(
                 new OnParameter(
-                    "Main.java",
-                    "edu.ucr.Main",
-                    "foo6(Map<String, Object>, Object, Object, Object, Object)",
-                    4),
+                    "Main.java", "edu.ucr.Main", "foo6(Map, Object, Object, Object, Object)", 4),
                 "javax.annotation.Nullable"))
         .start();
   }

--- a/injector/src/test/java/edu/ucr/cs/riple/injector/OnMethodInjectionTest.java
+++ b/injector/src/test/java/edu/ucr/cs/riple/injector/OnMethodInjectionTest.java
@@ -282,7 +282,7 @@ public class OnMethodInjectionTest extends BaseInjectorTest {
                 new OnMethod(
                     "Super.java",
                     "com.uber.Super",
-                    "computeResult(com.ibm.wala.ipa.slicer.Statement,java.util.Map<com.ibm.wala.ipa.callgraph.propagation.PointerKey,com.ibm.wala.util.intset.MutableIntSet>,com.ibm.wala.dataflow.graph.BitVectorSolver<? extends com.ibm.wala.ssa.ISSABasicBlock>,com.ibm.wala.util.intset.OrdinalSetMapping<com.ibm.wala.ipa.slicer.Statement>,com.ibm.wala.ipa.callgraph.CGNode,com.ibm.wala.ipa.modref.ExtendedHeapModel,com.ibm.wala.ipa.callgraph.propagation.PointerAnalysis<T>,java.util.Map<com.ibm.wala.ipa.callgraph.CGNode,com.ibm.wala.util.intset.OrdinalSet<com.ibm.wala.ipa.callgraph.propagation.PointerKey>>,com.ibm.wala.ssa.analysis.ExplodedControlFlowGraph,java.util.Map<java.lang.Integer,com.ibm.wala.ipa.slicer.NormalStatement>)"),
+                    "computeResult(com.ibm.wala.ipa.slicer.Statement,java.util.Map,com.ibm.wala.dataflow.graph.BitVectorSolver,com.ibm.wala.util.intset.OrdinalSetMapping,com.ibm.wala.ipa.callgraph.CGNode,com.ibm.wala.ipa.modref.ExtendedHeapModel,com.ibm.wala.ipa.callgraph.propagation.PointerAnalysis,java.util.Map,com.ibm.wala.ssa.analysis.ExplodedControlFlowGraph,java.util.Map)"),
                 "javax.annotation.Nullable"))
         .start();
   }
@@ -342,7 +342,7 @@ public class OnMethodInjectionTest extends BaseInjectorTest {
                 new OnMethod(
                     "Super.java",
                     "com.uber.Super",
-                    "<T>getReader(com.ibm.wala.shrikeCT.ClassReader.AttrIterator,java.lang.String,com.ibm.wala.classLoader.ShrikeClass.GetReader<T>)"),
+                    "<T>getReader(com.ibm.wala.shrikeCT.ClassReader.AttrIterator,java.lang.String,com.ibm.wala.classLoader.ShrikeClass.GetReader)"),
                 "javax.annotation.Nullable"))
         .start();
   }
@@ -367,7 +367,7 @@ public class OnMethodInjectionTest extends BaseInjectorTest {
         .addChanges(
             new AddMarkerAnnotation(
                 new OnMethod(
-                    "Main.java", "com.uber.Main", "format(java.lang.String,java.lang.Object...)"),
+                    "Main.java", "com.uber.Main", "format(java.lang.String,java.lang.Object[])"),
                 "javax.annotation.Initializer"))
         .start();
   }
@@ -414,9 +414,7 @@ public class OnMethodInjectionTest extends BaseInjectorTest {
         .addChanges(
             new AddMarkerAnnotation(
                 new OnMethod(
-                    "Main.java",
-                    "edu.ucr.Main",
-                    "foo6(Map<String, Object>, Object, Object, Object, Object)"),
+                    "Main.java", "edu.ucr.Main", "foo6(Map, Object, Object, Object, Object)"),
                 "javax.annotation.Nullable"))
         .start();
   }

--- a/injector/src/test/java/edu/ucr/cs/riple/injector/OnMethodSearchTest.java
+++ b/injector/src/test/java/edu/ucr/cs/riple/injector/OnMethodSearchTest.java
@@ -52,7 +52,7 @@ public class OnMethodSearchTest extends BaseInjectorTest {
         .addChanges(
             new AddMarkerAnnotation(
                 new OnMethod(
-                    "Main.java", "com.uber.Main", "Main(java.lang.String,java.lang.Object...)"),
+                    "Main.java", "com.uber.Main", "Main(java.lang.String,java.lang.Object[])"),
                 "javax.annotation.Initializer"))
         .start();
   }

--- a/injector/src/test/java/edu/ucr/cs/riple/injector/OnParameterInjectionTest.java
+++ b/injector/src/test/java/edu/ucr/cs/riple/injector/OnParameterInjectionTest.java
@@ -175,7 +175,7 @@ public class OnParameterInjectionTest extends BaseInjectorTest {
                 new OnParameter(
                     "ModRef.java",
                     "com.uber.ModRef",
-                    "computeMod(com.ibm.wala.ipa.callgraph.CallGraph,com.ibm.wala.ipa.callgraph.propagation.PointerAnalysis<T>,com.ibm.wala.ipa.slicer.HeapExclusions)",
+                    "computeMod(com.ibm.wala.ipa.callgraph.CallGraph,com.ibm.wala.ipa.callgraph.propagation.PointerAnalysis,com.ibm.wala.ipa.slicer.HeapExclusions)",
                     2),
                 "javax.annotation.Nullable"))
         .start();
@@ -235,7 +235,7 @@ public class OnParameterInjectionTest extends BaseInjectorTest {
                 new OnParameter(
                     "ModRef.java",
                     "com.uber.ModRef",
-                    "ModRef(com.ibm.wala.classLoader.IMethod,com.ibm.wala.ipa.callgraph.Context,com.ibm.wala.cfg.AbstractCFG<?,?>,com.ibm.wala.ssa.SSAInstruction[],com.ibm.wala.ssa.SSAOptions,java.util.Map<java.lang.Integer,com.ibm.wala.ssa.ConstantValue>)",
+                    "ModRef(com.ibm.wala.classLoader.IMethod,com.ibm.wala.ipa.callgraph.Context,com.ibm.wala.cfg.AbstractCFG,com.ibm.wala.ssa.SSAInstruction[],com.ibm.wala.ssa.SSAOptions,java.util.Map)",
                     5),
                 "javax.annotation.Nullable"))
         .start();
@@ -269,7 +269,7 @@ public class OnParameterInjectionTest extends BaseInjectorTest {
                 new OnParameter(
                     "WeakKeyReference.java",
                     "com.uber.WeakKeyReference",
-                    "WeakKeyReference(@org.checkerframework.checker.nullness.qual.Nullable K,java.lang.ref.ReferenceQueue<K>)",
+                    "WeakKeyReference(K,java.lang.ref.ReferenceQueue)",
                     1),
                 "javax.annotation.Nullable"))
         .start();
@@ -317,10 +317,7 @@ public class OnParameterInjectionTest extends BaseInjectorTest {
         .addChanges(
             new AddMarkerAnnotation(
                 new OnParameter(
-                    "Main.java",
-                    "edu.ucr.Main",
-                    "foo6(Map<String, Object>, Object, Object, Object, Object)",
-                    0),
+                    "Main.java", "edu.ucr.Main", "foo6(Map, Object, Object, Object, Object)", 0),
                 "javax.annotation.Nullable"))
         .start();
   }
@@ -367,10 +364,7 @@ public class OnParameterInjectionTest extends BaseInjectorTest {
         .addChanges(
             new AddMarkerAnnotation(
                 new OnParameter(
-                    "Main.java",
-                    "edu.ucr.Main",
-                    "foo6(Map<String, Object>, Object, Object, Object, Object)",
-                    1),
+                    "Main.java", "edu.ucr.Main", "foo6(Map, Object, Object, Object, Object)", 1),
                 "javax.annotation.Nullable"))
         .start();
   }
@@ -417,10 +411,7 @@ public class OnParameterInjectionTest extends BaseInjectorTest {
         .addChanges(
             new AddMarkerAnnotation(
                 new OnParameter(
-                    "Main.java",
-                    "edu.ucr.Main",
-                    "foo6(Map<String, Object>, Object, Object, Object, Object)",
-                    4),
+                    "Main.java", "edu.ucr.Main", "foo6(Map, Object, Object, Object, Object)", 4),
                 "javax.annotation.Nullable"))
         .start();
   }
@@ -464,10 +455,7 @@ public class OnParameterInjectionTest extends BaseInjectorTest {
         .addChanges(
             new AddMarkerAnnotation(
                 new OnParameter(
-                    "Main.java",
-                    "edu.ucr.Main",
-                    "foo6(Map<String, Object>, Object, Object, Object, Object)",
-                    1),
+                    "Main.java", "edu.ucr.Main", "foo6(Map, Object, Object, Object, Object)", 1),
                 "javax.annotation.Nullable"))
         .start();
   }
@@ -511,10 +499,7 @@ public class OnParameterInjectionTest extends BaseInjectorTest {
         .addChanges(
             new AddMarkerAnnotation(
                 new OnParameter(
-                    "Main.java",
-                    "edu.ucr.Main",
-                    "foo6(Map<String, Object>, Object, Object, Object, Object)",
-                    4),
+                    "Main.java", "edu.ucr.Main", "foo6(Map, Object, Object, Object, Object)", 4),
                 "javax.annotation.Nullable"))
         .start();
   }
@@ -558,10 +543,7 @@ public class OnParameterInjectionTest extends BaseInjectorTest {
         .addChanges(
             new RemoveAnnotation(
                 new OnParameter(
-                    "Main.java",
-                    "edu.ucr.Main",
-                    "foo6(Map<String, Object>, Object, Object, Object, Object)",
-                    0),
+                    "Main.java", "edu.ucr.Main", "foo6(Map, Object, Object, Object, Object)", 0),
                 "javax.annotation.Nullable"))
         .start();
   }
@@ -605,10 +587,7 @@ public class OnParameterInjectionTest extends BaseInjectorTest {
         .addChanges(
             new RemoveAnnotation(
                 new OnParameter(
-                    "Main.java",
-                    "edu.ucr.Main",
-                    "foo6(Map<String, Object>, Object, Object, Object, Object)",
-                    4),
+                    "Main.java", "edu.ucr.Main", "foo6(Map, Object, Object, Object, Object)", 4),
                 "javax.annotation.Nullable"))
         .start();
   }
@@ -652,38 +631,23 @@ public class OnParameterInjectionTest extends BaseInjectorTest {
         .addChanges(
             new AddMarkerAnnotation(
                 new OnParameter(
-                    "Main.java",
-                    "edu.ucr.Main",
-                    "foo6(Map<String, Object>, Object, Object, Object, Object)",
-                    0),
+                    "Main.java", "edu.ucr.Main", "foo6(Map, Object, Object, Object, Object)", 0),
                 "javax.annotation.Nullable"),
             new AddMarkerAnnotation(
                 new OnParameter(
-                    "Main.java",
-                    "edu.ucr.Main",
-                    "foo6(Map<String, Object>, Object, Object, Object, Object)",
-                    1),
+                    "Main.java", "edu.ucr.Main", "foo6(Map, Object, Object, Object, Object)", 1),
                 "javax.annotation.Nullable"),
             new AddMarkerAnnotation(
                 new OnParameter(
-                    "Main.java",
-                    "edu.ucr.Main",
-                    "foo6(Map<String, Object>, Object, Object, Object, Object)",
-                    2),
+                    "Main.java", "edu.ucr.Main", "foo6(Map, Object, Object, Object, Object)", 2),
                 "javax.annotation.Nullable"),
             new AddMarkerAnnotation(
                 new OnParameter(
-                    "Main.java",
-                    "edu.ucr.Main",
-                    "foo6(Map<String, Object>, Object, Object, Object, Object)",
-                    3),
+                    "Main.java", "edu.ucr.Main", "foo6(Map, Object, Object, Object, Object)", 3),
                 "javax.annotation.Nullable"),
             new AddMarkerAnnotation(
                 new OnParameter(
-                    "Main.java",
-                    "edu.ucr.Main",
-                    "foo6(Map<String, Object>, Object, Object, Object, Object)",
-                    4),
+                    "Main.java", "edu.ucr.Main", "foo6(Map, Object, Object, Object, Object)", 4),
                 "javax.annotation.Nullable"))
         .start();
   }
@@ -727,38 +691,23 @@ public class OnParameterInjectionTest extends BaseInjectorTest {
         .addChanges(
             new RemoveAnnotation(
                 new OnParameter(
-                    "Main.java",
-                    "edu.ucr.Main",
-                    "foo6(Map<String, Object>, Object, Object, Object, Object)",
-                    0),
+                    "Main.java", "edu.ucr.Main", "foo6(Map, Object, Object, Object, Object)", 0),
                 "javax.annotation.Nullable"),
             new RemoveAnnotation(
                 new OnParameter(
-                    "Main.java",
-                    "edu.ucr.Main",
-                    "foo6(Map<String, Object>, Object, Object, Object, Object)",
-                    1),
+                    "Main.java", "edu.ucr.Main", "foo6(Map, Object, Object, Object, Object)", 1),
                 "javax.annotation.Nullable"),
             new RemoveAnnotation(
                 new OnParameter(
-                    "Main.java",
-                    "edu.ucr.Main",
-                    "foo6(Map<String, Object>, Object, Object, Object, Object)",
-                    2),
+                    "Main.java", "edu.ucr.Main", "foo6(Map, Object, Object, Object, Object)", 2),
                 "javax.annotation.Nullable"),
             new RemoveAnnotation(
                 new OnParameter(
-                    "Main.java",
-                    "edu.ucr.Main",
-                    "foo6(Map<String, Object>, Object, Object, Object, Object)",
-                    3),
+                    "Main.java", "edu.ucr.Main", "foo6(Map, Object, Object, Object, Object)", 3),
                 "javax.annotation.Nullable"),
             new RemoveAnnotation(
                 new OnParameter(
-                    "Main.java",
-                    "edu.ucr.Main",
-                    "foo6(Map<String, Object>, Object, Object, Object, Object)",
-                    4),
+                    "Main.java", "edu.ucr.Main", "foo6(Map, Object, Object, Object, Object)", 4),
                 "javax.annotation.Nullable"))
         .start();
   }

--- a/injector/src/test/java/edu/ucr/cs/riple/injector/RemovalTest.java
+++ b/injector/src/test/java/edu/ucr/cs/riple/injector/RemovalTest.java
@@ -58,10 +58,7 @@ public class RemovalTest extends BaseInjectorTest {
             "}")
         .addChanges(
             new RemoveAnnotation(
-                new OnMethod(
-                    "Super.java",
-                    "com.uber.Super",
-                    "test(@javax.annotation.Nullable java.lang.Object)"),
+                new OnMethod("Super.java", "com.uber.Super", "test(java.lang.Object)"),
                 "javax.annotation.Nullable"))
         .start();
   }
@@ -86,11 +83,7 @@ public class RemovalTest extends BaseInjectorTest {
             "}")
         .addChanges(
             new RemoveAnnotation(
-                new OnParameter(
-                    "Super.java",
-                    "com.uber.Super",
-                    "test(@javax.annotation.Nullable java.lang.Object)",
-                    0),
+                new OnParameter("Super.java", "com.uber.Super", "test(java.lang.Object)", 0),
                 "javax.annotation.Nullable"))
         .start();
   }
@@ -118,11 +111,7 @@ public class RemovalTest extends BaseInjectorTest {
             "}")
         .addChanges(
             new RemoveAnnotation(
-                new OnParameter(
-                    "Super.java",
-                    "com.uber.Super",
-                    "test(@javax.annotation.Nullable java.lang.Object)",
-                    0),
+                new OnParameter("Super.java", "com.uber.Super", "test(java.lang.Object)", 0),
                 "javax.annotation.Nullable"));
     assertThrows(AssertionError.class, () -> injectorTestHelper.start());
   }


### PR DESCRIPTION
~~This PR requires release of NullAway `0.10.10`.~~ NullAway `0.10.10` is released.

This PR updates NullAway test version to `0.10.10`. The main update in this version is on the serialization change. 

In the newest version, method signatures does not contain any annotation or type arguments, this PR adapts injector to work with this serialization to locate the method and also update scanner to use the same logic for serializing method signatures.


Please note that previously Injector was written to parse complicated cases such as case below:

```
foo(@edu.ucr.Custom({"arg1, "arg2}) java.util.Map<A.B.C, A.B.D>)
```

Wheres in the latest version of serialization for the method above, we receive input below:
```
foo(java.util.Map)
```

Therefore, the parsing logic, along the input for some unit tests had to be updated. 

