### PR TITLE
Add javadoc to test package for annotator-core

### DIFF
--- a/annotator-core/src/test/java/edu/ucr/cs/riple/core/AnalysisModeTest.java
+++ b/annotator-core/src/test/java/edu/ucr/cs/riple/core/AnalysisModeTest.java
@@ -133,7 +133,7 @@ public class AnalysisModeTest extends BaseCoreTest {
         .disableBailOut()
         .enableDownstreamDependencyAnalysis(STRICT)
         // This causes the test to report a failure if any errors remain when building the target.
-        .enableForceResolve()
+        .suppressRemainingErrors()
         .start();
   }
 }

--- a/annotator-core/src/test/java/edu/ucr/cs/riple/core/BaseCoreTest.java
+++ b/annotator-core/src/test/java/edu/ucr/cs/riple/core/BaseCoreTest.java
@@ -37,15 +37,21 @@ import org.junit.rules.TemporaryFolder;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
 
+/** Base class for all core tests. */
 @RunWith(JUnit4.class)
 public abstract class BaseCoreTest {
 
+  /** Temporary folder for each test. */
   @Rule public final TemporaryFolder temporaryFolder = new TemporaryFolder();
-
+  /** Name of the used project template */
   protected final String projectTemplate;
+  /** List of modules to be tested */
   protected final List<String> modules;
+  /** Path to the unit test project */
   protected Path unitTestProjectPath;
+  /** Path to the output directory */
   protected Path outDirPath;
+  /** Helper class for core tests */
   protected CoreTestHelper coreTestHelper;
 
   public BaseCoreTest(String projectTemplate, List<String> modules) {

--- a/annotator-core/src/test/java/edu/ucr/cs/riple/core/CoreTest.java
+++ b/annotator-core/src/test/java/edu/ucr/cs/riple/core/CoreTest.java
@@ -109,7 +109,7 @@ public class CoreTest extends BaseCoreTest {
             "     run(null);",
             "   }",
             "}")
-        .requestCompleteLoop()
+        .activateOuterLoop()
         .addExpectedReports(
             new TReport(new OnParameter("Main.java", "test.Main", "run(java.lang.Object)", 0), 0),
             new TReport(new OnMethod("Main.java", "test.Main", "run(java.lang.Object)"), -1))
@@ -179,7 +179,7 @@ public class CoreTest extends BaseCoreTest {
         .toDepth(1)
         .addExpectedReports(
             new TReport(new OnParameter("Main.java", "test.Main", "Main(java.lang.Object)", 0), 1))
-        .enableForceResolve()
+        .suppressRemainingErrors()
         .start();
     Set<AddAnnotation> expectedAnnotations =
         Set.of(
@@ -217,7 +217,7 @@ public class CoreTest extends BaseCoreTest {
             new TReport(new OnField("Main.java", "test.Main", singleton("f5")), 1))
         .toDepth(1)
         // This causes the test to report a failure if any errors remain when building the target.
-        .enableForceResolve()
+        .suppressRemainingErrors()
         .start();
   }
 
@@ -332,7 +332,7 @@ public class CoreTest extends BaseCoreTest {
             new TReport(new OnField("Foo.java", "test.Foo", Set.of("f4")), 1),
             new TReport(new OnField("Foo.java", "test.Foo", Set.of("f5")), 0))
         .toDepth(1)
-        .enableForceResolve()
+        .suppressRemainingErrors()
         .start();
     Path srcRoot = coreTestHelper.getSourceRoot();
     Set<AddAnnotation> expectedAnnotations =
@@ -399,7 +399,7 @@ public class CoreTest extends BaseCoreTest {
             new TReport(new OnField("Foo.java", "test.Foo", Set.of("f3")), 2),
             new TReport(new OnField("Foo.java", "test.Foo", Set.of("f4")), 1))
         .toDepth(1)
-        .enableForceResolve()
+        .suppressRemainingErrors()
         .start();
     String pathToFoo = coreTestHelper.getSourceRoot().resolve("Foo.java").toString();
     Set<AddAnnotation> expectedAnnotations =
@@ -491,7 +491,7 @@ public class CoreTest extends BaseCoreTest {
             "}")
         .toDepth(5)
         .addExpectedReports(new TReport(new OnField("A.java", "test.A", singleton("f")), -3))
-        .enableForceResolve()
+        .suppressRemainingErrors()
         .start();
     List<AddAnnotation> expectedAnnotations =
         List.of(

--- a/annotator-core/src/test/java/edu/ucr/cs/riple/core/DownstreamAnalysisTest.java
+++ b/annotator-core/src/test/java/edu/ucr/cs/riple/core/DownstreamAnalysisTest.java
@@ -93,7 +93,7 @@ public class DownstreamAnalysisTest extends BaseCoreTest {
                         == found.getLowerBoundEffectOnDownstreamDependencies())
         .toDepth(5)
         .enableDownstreamDependencyAnalysis()
-        .requestCompleteLoop()
+        .activateOuterLoop()
         .start();
   }
 
@@ -118,7 +118,7 @@ public class DownstreamAnalysisTest extends BaseCoreTest {
                         == found.getUpperBoundEffectOnDownstreamDependencies())
         .toDepth(5)
         .enableDownstreamDependencyAnalysis()
-        .requestCompleteLoop()
+        .activateOuterLoop()
         .start();
   }
 }

--- a/annotator-core/src/test/java/edu/ucr/cs/riple/core/InheritanceTest.java
+++ b/annotator-core/src/test/java/edu/ucr/cs/riple/core/InheritanceTest.java
@@ -71,7 +71,7 @@ public class InheritanceTest extends BaseCoreTest {
   public void builderTest() {
     coreTestHelper
         .addInputDirectory("test", "builder")
-        .requestCompleteLoop()
+        .activateOuterLoop()
         .setPredicate((expected, found) -> expected.testEquals(coreTestHelper.getConfig(), found))
         .addExpectedReports(
             new TReport(new OnField("A.java", "test.A", singleton("arg3")), -1),

--- a/annotator-core/src/test/java/edu/ucr/cs/riple/core/tools/CoreTestHelper.java
+++ b/annotator-core/src/test/java/edu/ucr/cs/riple/core/tools/CoreTestHelper.java
@@ -41,56 +41,95 @@ import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
-import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
-import java.util.Map;
 import java.util.Set;
 import java.util.function.BiPredicate;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 import org.apache.commons.io.FileUtils;
 
+/** Helper class for testing the core module. */
 public class CoreTestHelper {
 
+  /** The expected reports which gets compared with computed reports when process is finished. */
   private final Set<TReport> expectedReports;
+  /** Path to the project. */
   private final Path projectPath;
+  /** Path to source directory of target project. */
   private final Path srcSet;
+  /**
+   * List of modules to be analyzed. Module at index {@code 0} is the target module and all others
+   * depend on it.
+   */
   private final List<String> modules;
+  /** Path to root directory where all output exists including the project. */
   private final Path outDirPath;
-  private final Map<String, String[]> fileMap;
+  /**
+   * Predicate to be used for comparing reports. If not set by the user, {@link DEFAULT_PREDICATE}
+   * will be used.
+   */
   private BiPredicate<TReport, Report> predicate;
+  /** Depth of the analysis. */
   private int depth = 1;
-  private boolean requestCompleteLoop = false;
+  /** Outer loop activation. Deactivated by default */
+  private boolean outerLoopActivated = false;
+  /** Bailout activation. Deactivated by default */
   private boolean disableBailout = false;
-  private boolean forceResolveActivated = false;
+  /** Force resolve activation. Deactivated by default */
+  private boolean suppressRemainingErrors = false;
+  /** Downstream dependency analysis activation. Deactivated by default */
   private boolean downstreamDependencyAnalysisActivated = false;
+  /** Inference activation. Activated by default */
   private boolean deactivateInference = false;
+  /** Analysis mode. */
   private AnalysisMode mode = AnalysisMode.LOCAL;
+  /** Annotator config. */
   private Config config;
 
   public CoreTestHelper(Path projectPath, Path outDirPath, List<String> modules) {
     this.projectPath = projectPath;
     this.outDirPath = outDirPath;
     this.expectedReports = new HashSet<>();
-    this.fileMap = new HashMap<>();
     this.srcSet = this.projectPath.resolve("src").resolve("main").resolve("java").resolve("test");
     this.modules = modules;
   }
 
+  /**
+   * Adds source code received as lines at the given output path.
+   *
+   * @param path Relative path to the file to be created from root source directory.
+   * @param lines Lines of source code to be written.
+   * @return This instance of {@link CoreTestHelper}.
+   */
   public CoreTestHelper addInputLines(String path, String... lines) {
-    if (fileMap.containsKey(path)) {
-      throw new IllegalArgumentException("File at path: " + path + " already exists.");
+    try {
+      FileUtils.writeLines(srcSet.resolve(path).toFile(), Arrays.asList(lines));
+    } catch (IOException e) {
+      throw new RuntimeException("Failed to write line at: " + path, e);
     }
-    fileMap.put(path, lines);
     return this;
   }
 
+  /**
+   * Sets the predicate to be used for comparing reports. If not set by the user, {@link
+   * DEFAULT_PREDICATE} will be used.
+   *
+   * @param predicate Predicate to be used for comparing reports.
+   * @return This instance of {@link CoreTestHelper}.
+   */
   public CoreTestHelper setPredicate(BiPredicate<TReport, Report> predicate) {
     this.predicate = predicate;
     return this;
   }
 
+  /**
+   * Adds source code which is read from resources at the given output path.
+   *
+   * @param path Relative path to the file to be created from root source directory.
+   * @param inputFilePath Path to the file in resources.
+   * @return This instance of {@link CoreTestHelper}.
+   */
   public CoreTestHelper addInputSourceFile(String path, String inputFilePath) {
     try {
       return addInputLines(
@@ -102,11 +141,23 @@ public class CoreTestHelper {
     }
   }
 
+  /**
+   * Disables bailout.
+   *
+   * @return This instance of {@link CoreTestHelper}.
+   */
   public CoreTestHelper disableBailOut() {
     disableBailout = true;
     return this;
   }
 
+  /**
+   * Adds source code which is read from a directory resources at the given output path.
+   *
+   * @param path Relative path to the directory to be created from root source directory.
+   * @param inputDirectoryPath Path to the directory in resources.
+   * @return This instance of {@link CoreTestHelper}.
+   */
   public CoreTestHelper addInputDirectory(String path, String inputDirectoryPath) {
     Path dir = Utility.getPathOfResource(inputDirectoryPath);
     try {
@@ -117,21 +168,44 @@ public class CoreTestHelper {
     return this;
   }
 
+  /**
+   * Adds expected reports to be compared with computed reports when test process is finished.
+   *
+   * @param reports Expected Reports.
+   * @return This instance of {@link CoreTestHelper}.
+   */
   public CoreTestHelper addExpectedReports(TReport... reports) {
     this.expectedReports.addAll(Arrays.asList(reports));
     return this;
   }
 
+  /**
+   * Defines the depth of the analysis.
+   *
+   * @param depth Depth of the analysis.
+   * @return This instance of {@link CoreTestHelper}.
+   */
   public CoreTestHelper toDepth(int depth) {
     this.depth = depth;
     return this;
   }
 
-  public CoreTestHelper requestCompleteLoop() {
-    this.requestCompleteLoop = true;
+  /**
+   * Activates outer loop.
+   *
+   * @return This instance of {@link CoreTestHelper}.
+   */
+  public CoreTestHelper activateOuterLoop() {
+    this.outerLoopActivated = true;
     return this;
   }
 
+  /**
+   * Activates downstream dependency analysis.
+   *
+   * @param mode Analysis mode.
+   * @return This instance of {@link CoreTestHelper}.
+   */
   public CoreTestHelper enableDownstreamDependencyAnalysis(AnalysisMode mode) {
     this.downstreamDependencyAnalysisActivated = true;
     if (mode.equals(AnalysisMode.LOCAL)) {
@@ -142,39 +216,47 @@ public class CoreTestHelper {
     return this;
   }
 
-  public CoreTestHelper enableForceResolve() {
-    this.forceResolveActivated = true;
+  /**
+   * Suppresses remaining errors.
+   *
+   * @return This instance of {@link CoreTestHelper}.
+   */
+  public CoreTestHelper suppressRemainingErrors() {
+    this.suppressRemainingErrors = true;
     return this;
   }
 
   public CoreTestHelper deactivateInference() {
     this.deactivateInference = true;
-    this.forceResolveActivated = true;
+    this.suppressRemainingErrors = true;
     return this;
   }
 
+  /**
+   * Activates downstream dependency analysis with default mode.
+   *
+   * @return This instance of {@link CoreTestHelper}.
+   */
   public CoreTestHelper enableDownstreamDependencyAnalysis() {
     return enableDownstreamDependencyAnalysis(AnalysisMode.LOWER_BOUND);
   }
 
+  /** Starts the test process. */
   public void start() {
     Path configPath = outDirPath.resolve("config.json");
-    createFiles();
     checkSourcePackages();
     makeAnnotatorConfigFile(configPath);
     config = new Config(configPath);
     Annotator annotator = new Annotator(config);
     annotator.start();
     if (predicate == null) {
-      predicate =
-          (expected, found) ->
-              expected.root.change.location.equals(found.root.change.location)
-                  && expected.getExpectedValue() == found.getOverallEffect(config);
+      predicate = DEFAULT_PREDICATE.create(config);
     }
     compare(new ArrayList<>(annotator.cache.reports()));
     checkBuildsStatus();
   }
 
+  /** Checks if there is any build error including NullAway errors after the analysis. */
   private void checkBuildsStatus() {
     if (mode.equals(AnalysisMode.STRICT) && modules.size() > 1) {
       // Build downstream dependencies.
@@ -196,7 +278,7 @@ public class CoreTestHelper {
         }
       }
     }
-    if (forceResolveActivated) {
+    if (suppressRemainingErrors) {
       // Check no error will be reported in Target module
       Utility.executeCommand(config.buildCommand);
       Path path = outDirPath.resolve("0").resolve("errors.tsv");
@@ -227,6 +309,11 @@ public class CoreTestHelper {
     }
   }
 
+  /**
+   * Compares expected reports with actual reports.
+   *
+   * @param actualOutput Actual reports.
+   */
   private void compare(Collection<Report> actualOutput) {
     List<Report> notFound = new ArrayList<>();
     for (TReport expected : expectedReports) {
@@ -259,6 +346,11 @@ public class CoreTestHelper {
     fail(errorMessage.toString());
   }
 
+  /**
+   * Creates a config file for annotator.
+   *
+   * @param configPath Path to the config file.
+   */
   public void makeAnnotatorConfigFile(Path configPath) {
     Config.Builder builder = new Config.Builder();
     final int[] id = {0};
@@ -279,12 +371,12 @@ public class CoreTestHelper {
     builder.bailout = !disableBailout;
     builder.redirectBuildOutputToStdErr = true;
     builder.chain = true;
-    builder.outerLoopActivation = requestCompleteLoop;
+    builder.outerLoopActivation = outerLoopActivated;
     builder.useParallelProcessor = true;
     builder.downStreamDependenciesAnalysisActivated = downstreamDependencyAnalysisActivated;
     builder.mode = mode;
     builder.inferenceActivated = !deactivateInference;
-    builder.forceResolveActivation = forceResolveActivated;
+    builder.forceResolveActivation = suppressRemainingErrors;
     builder.useCacheImpact = true;
     builder.sourceTypes.add(SourceType.LOMBOK);
     builder.cache = true;
@@ -330,17 +422,11 @@ public class CoreTestHelper {
     return Boolean.parseBoolean(value);
   }
 
-  private void createFiles() {
-    fileMap.forEach(
-        (key, value) -> {
-          try {
-            FileUtils.writeLines(srcSet.resolve(key).toFile(), Arrays.asList(value));
-          } catch (IOException e) {
-            throw new RuntimeException("Failed to write line at: " + key, e);
-          }
-        });
-  }
-
+  /**
+   * Getter for config.
+   *
+   * @return Config instance.
+   */
   public Config getConfig() {
     if (config == null) {
       throw new IllegalStateException(
@@ -362,5 +448,32 @@ public class CoreTestHelper {
         .resolve("main")
         .resolve("java")
         .resolve("test");
+  }
+
+  /** Default predicate for comparing expected and actual reports. */
+  static class DEFAULT_PREDICATE implements BiPredicate<TReport, Report> {
+
+    /** The config. */
+    private final Config config;
+
+    private DEFAULT_PREDICATE(Config config) {
+      this.config = config;
+    }
+
+    @Override
+    public boolean test(TReport expected, Report found) {
+      return expected.root.change.location.equals(found.root.change.location)
+          && expected.getExpectedValue() == found.getOverallEffect(config);
+    }
+
+    /**
+     * Creates a new instance of {@link DEFAULT_PREDICATE}.
+     *
+     * @param config the config
+     * @return the default predicate
+     */
+    public static DEFAULT_PREDICATE create(Config config) {
+      return new DEFAULT_PREDICATE(config);
+    }
   }
 }

--- a/annotator-core/src/test/java/edu/ucr/cs/riple/core/tools/CoreTestHelper.java
+++ b/annotator-core/src/test/java/edu/ucr/cs/riple/core/tools/CoreTestHelper.java
@@ -450,7 +450,10 @@ public class CoreTestHelper {
         .resolve("test");
   }
 
-  /** Default predicate for comparing expected and actual reports. */
+  /**
+   * Default predicate for comparing expected and actual reports. The Default predicate only checks
+   * if the expected effect is computed for the root fix along its tree.
+   */
   static class DEFAULT_PREDICATE implements BiPredicate<TReport, Report> {
 
     /** The config. */

--- a/annotator-core/src/test/java/edu/ucr/cs/riple/core/tools/TReport.java
+++ b/annotator-core/src/test/java/edu/ucr/cs/riple/core/tools/TReport.java
@@ -41,6 +41,7 @@ import javax.annotation.Nullable;
  */
 public class TReport extends Report {
 
+  /** The expected effect value for a root fix along its tree. */
   private final int expectedValue;
 
   public TReport(Location root, int effect) {

--- a/annotator-core/src/test/java/edu/ucr/cs/riple/core/tools/Utility.java
+++ b/annotator-core/src/test/java/edu/ucr/cs/riple/core/tools/Utility.java
@@ -35,6 +35,7 @@ import java.util.Set;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
+/** Utility class for tests. */
 public class Utility {
 
   /**

--- a/annotator-core/src/test/java/edu/ucr/cs/riple/core/tools/Utility.java
+++ b/annotator-core/src/test/java/edu/ucr/cs/riple/core/tools/Utility.java
@@ -56,20 +56,26 @@ public class Utility {
     }
   }
 
+  /**
+   * Gets the path of a resource from the given relative path.
+   *
+   * @param relativePath The relative path of the resource.
+   * @return The path of the resource.
+   */
   public static Path getPathOfResource(String relativePath) {
     return Paths.get(
         Objects.requireNonNull(Utility.class.getClassLoader().getResource(relativePath)).getFile());
   }
 
+  /**
+   * Creates the command to change directory to the given path.
+   *
+   * @param path The path to change directory to.
+   * @return The command to change directory to the given path.
+   */
   public static String changeDirCommand(Path path) {
     String os = System.getProperty("os.name").toLowerCase();
     return (os.startsWith("windows") ? "dir" : "cd") + " " + path;
-  }
-
-  public static ProcessBuilder createProcessInstance() {
-    ProcessBuilder pb = new ProcessBuilder();
-    String os = System.getProperty("os.name").toLowerCase();
-    return os.startsWith("windows") ? pb.command("cmd.exe", "/c") : pb.command("bash", "-c");
   }
 
   /**


### PR DESCRIPTION
This PR adds the missing javadoc to test package in `annotator-core` module.