### PR TITLE
Convert Modification abstract class to an interface

### DIFF
--- a/injector/src/main/java/edu/ucr/cs/riple/injector/Printer.java
+++ b/injector/src/main/java/edu/ucr/cs/riple/injector/Printer.java
@@ -32,10 +32,13 @@ import edu.ucr.cs.riple.injector.offsets.FileOffsetStore;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
-import java.util.Comparator;
+import java.util.Arrays;
+import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
 import java.util.Set;
+import java.util.SortedSet;
+import java.util.TreeSet;
 
 /**
  * Applies the text modification instances to source file. Text modifications are applied according
@@ -47,7 +50,6 @@ public class Printer {
   private final Path path;
   /** Lines of source file. */
   private final List<String> lines;
-
   /** Offset store for recording changes in source code. */
   private final FileOffsetStore offsetStore;
 
@@ -69,14 +71,9 @@ public class Printer {
   public void applyModifications(Set<Modification> modifications) {
     // Modification are sorted to start from the last position, to make the changes ineffective to
     // current computed offsets.
-    modifications.stream()
-        .sorted(
-            Comparator.comparingInt((Modification o) -> o.startPosition.line)
-                .thenComparingInt(o -> o.startPosition.column)
-                // To make the tests produce deterministic results.
-                .thenComparing(o -> o.content)
-                .reversed())
-        .forEach(modification -> modification.visit(lines, offsetStore));
+    SortedSet<Modification> reversedSortedSet = new TreeSet<>(Collections.reverseOrder());
+    reversedSortedSet.addAll(modifications);
+    reversedSortedSet.forEach(modification -> modification.visit(lines, offsetStore));
   }
 
   /**
@@ -172,5 +169,16 @@ public class Printer {
       throw new RuntimeException(e);
     }
     return offsetStore;
+  }
+
+  public static void main(String[] args) {
+    // Create a sorted set of integers
+    Set<Integer> set = new TreeSet<>(Arrays.asList(5, 3, 8, 1, 9, 2, 7));
+    System.out.println("Original Set: " + set);
+
+    // Create a reversed sorted set
+    Set<Integer> reversedSet = new TreeSet<>(Collections.reverseOrder());
+    reversedSet.addAll(set);
+    System.out.println("Reversed Set: " + reversedSet);
   }
 }

--- a/injector/src/main/java/edu/ucr/cs/riple/injector/Printer.java
+++ b/injector/src/main/java/edu/ucr/cs/riple/injector/Printer.java
@@ -32,7 +32,6 @@ import edu.ucr.cs.riple.injector.offsets.FileOffsetStore;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
-import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
@@ -169,16 +168,5 @@ public class Printer {
       throw new RuntimeException(e);
     }
     return offsetStore;
-  }
-
-  public static void main(String[] args) {
-    // Create a sorted set of integers
-    Set<Integer> set = new TreeSet<>(Arrays.asList(5, 3, 8, 1, 9, 2, 7));
-    System.out.println("Original Set: " + set);
-
-    // Create a reversed sorted set
-    Set<Integer> reversedSet = new TreeSet<>(Collections.reverseOrder());
-    reversedSet.addAll(set);
-    System.out.println("Reversed Set: " + reversedSet);
   }
 }

--- a/injector/src/main/java/edu/ucr/cs/riple/injector/modifications/Deletion.java
+++ b/injector/src/main/java/edu/ucr/cs/riple/injector/modifications/Deletion.java
@@ -30,7 +30,7 @@ import edu.ucr.cs.riple.injector.offsets.FileOffsetStore;
 import java.util.List;
 
 /** Represents a deletion of a content in the source file. */
-public class Deletion extends Modification {
+public class Deletion extends SinglePositionModification {
 
   /** The end position of content which should be removed. */
   private final Position endPosition;

--- a/injector/src/main/java/edu/ucr/cs/riple/injector/modifications/Insertion.java
+++ b/injector/src/main/java/edu/ucr/cs/riple/injector/modifications/Insertion.java
@@ -29,7 +29,7 @@ import edu.ucr.cs.riple.injector.offsets.FileOffsetStore;
 import java.util.List;
 
 /** Represents an insertion of a content in the source file. */
-public class Insertion extends Modification {
+public class Insertion extends SinglePositionModification {
 
   public Insertion(String content, Position position) {
     super(content, position);

--- a/injector/src/main/java/edu/ucr/cs/riple/injector/modifications/Modification.java
+++ b/injector/src/main/java/edu/ucr/cs/riple/injector/modifications/Modification.java
@@ -24,27 +24,14 @@
 
 package edu.ucr.cs.riple.injector.modifications;
 
-import com.github.javaparser.Position;
 import edu.ucr.cs.riple.injector.offsets.FileOffsetStore;
 import java.util.List;
-import java.util.Objects;
 
 /**
  * Represents a text modification in the source file which are translation of {@link
  * edu.ucr.cs.riple.injector.changes.Change} instances.
  */
-public abstract class Modification {
-
-  /** Starting position where the modification should be applied in the source file. */
-  public final Position startPosition;
-  /** Content of modification. */
-  public final String content;
-
-  public Modification(String content, Position startPosition) {
-    // Position in javaparser is not 0 indexed and line and column fields are final.
-    this.startPosition = new Position(startPosition.line - 1, startPosition.column - 1);
-    this.content = content;
-  }
+public interface Modification extends Comparable<Modification> {
 
   /**
    * Visits the source file as list of lines and applies its modification to it.
@@ -52,22 +39,21 @@ public abstract class Modification {
    * @param lines List of lines of the target source code.
    * @param offsetStore Offset change info of the original version.
    */
-  public abstract void visit(List<String> lines, FileOffsetStore offsetStore);
+  void visit(List<String> lines, FileOffsetStore offsetStore);
 
-  @Override
-  public boolean equals(Object o) {
-    if (this == o) {
-      return true;
-    }
-    if (!(o instanceof Modification)) {
-      return false;
-    }
-    Modification that = (Modification) o;
-    return startPosition.equals(that.startPosition) && content.equals(that.content);
-  }
+  /**
+   * Returns the line number of the beginning of the modification on the source file. Required to
+   * sort a collection of modifications.
+   *
+   * @return Tine line number of the beginning of the modification on the source file.
+   */
+  int getStartLine();
 
-  @Override
-  public int hashCode() {
-    return Objects.hash(startPosition, content);
-  }
+  /**
+   * Returns the column number of the beginning of the modification on the source file. Required to
+   * sort a collection of modifications.
+   *
+   * @return Tine column number of the beginning of the modification on the source file.
+   */
+  int getStarColumn();
 }

--- a/injector/src/main/java/edu/ucr/cs/riple/injector/modifications/Replacement.java
+++ b/injector/src/main/java/edu/ucr/cs/riple/injector/modifications/Replacement.java
@@ -29,7 +29,7 @@ import edu.ucr.cs.riple.injector.offsets.FileOffsetStore;
 import java.util.List;
 
 /** Represents a replacement of a content in the source file. */
-public class Replacement extends Modification {
+public class Replacement extends SinglePositionModification {
 
   /** The end position of the content that should be replaced. */
   private final Position endPosition;

--- a/injector/src/main/java/edu/ucr/cs/riple/injector/modifications/SinglePositionModification.java
+++ b/injector/src/main/java/edu/ucr/cs/riple/injector/modifications/SinglePositionModification.java
@@ -1,0 +1,95 @@
+/*
+ * MIT License
+ *
+ * Copyright (c) 2023 Nima Karimipour
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+package edu.ucr.cs.riple.injector.modifications;
+
+import com.github.javaparser.Position;
+import java.util.Objects;
+
+/**
+ * Base class for modifications which require only a single string modification at a position in the
+ * source file.
+ */
+public abstract class SinglePositionModification implements Modification {
+
+  /** Starting position where the modification should be applied in the source file. */
+  public final Position startPosition;
+  /** Content of modification. */
+  public final String content;
+
+  public SinglePositionModification(String content, Position startPosition) {
+    // Position in javaparser is not 0 indexed and line and column fields are final.
+    this.startPosition = new Position(startPosition.line - 1, startPosition.column - 1);
+    this.content = content;
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (!(o instanceof SinglePositionModification)) {
+      return false;
+    }
+    SinglePositionModification that = (SinglePositionModification) o;
+    return startPosition.equals(that.startPosition) && content.equals(that.content);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(startPosition, content);
+  }
+
+  @Override
+  public int getStartLine() {
+    return startPosition.line;
+  }
+
+  @Override
+  public int getStarColumn() {
+    return startPosition.column;
+  }
+
+  @Override
+  public int compareTo(Modification o) {
+    if (startPosition.line < o.getStartLine()) {
+      return -1;
+    }
+    if (startPosition.line > o.getStartLine()) {
+      return 1;
+    }
+    if (startPosition.column < o.getStarColumn()) {
+      return -1;
+    }
+    if (startPosition.column > o.getStarColumn()) {
+      return 1;
+    }
+    if (o instanceof SinglePositionModification) {
+      // to produce deterministic results in unit tests to avoid flaky CI issues. In practice, the
+      // order is not important anymore and will not cause any problem.
+      return content.compareTo(((SinglePositionModification) o).content);
+    }
+    return 0;
+  }
+}


### PR DESCRIPTION
This PR updates the `Modification` abstract class to an interface. It prepares the architecture for upcoming PR which enables adding annotations in local variables along its type arguments.