### PR TITLE
Refactor Change#visit method in injector module

### DIFF
--- a/injector/src/main/java/edu/ucr/cs/riple/injector/changes/AddMarkerAnnotation.java
+++ b/injector/src/main/java/edu/ucr/cs/riple/injector/changes/AddMarkerAnnotation.java
@@ -27,6 +27,7 @@ import com.github.javaparser.ast.NodeList;
 import com.github.javaparser.ast.expr.AnnotationExpr;
 import com.github.javaparser.ast.expr.MarkerAnnotationExpr;
 import com.github.javaparser.ast.nodeTypes.NodeWithAnnotations;
+import com.github.javaparser.ast.nodeTypes.NodeWithRange;
 import edu.ucr.cs.riple.injector.location.Location;
 import edu.ucr.cs.riple.injector.modifications.Insertion;
 import edu.ucr.cs.riple.injector.modifications.Modification;
@@ -45,7 +46,11 @@ public class AddMarkerAnnotation extends AddAnnotation {
 
   @Override
   @Nullable
-  public Modification visit(NodeWithAnnotations<?> node, Range range) {
+  public <T extends NodeWithAnnotations<?> & NodeWithRange<?>> Modification visit(T node) {
+    if (node.getRange().isEmpty()) {
+      return null;
+    }
+    Range range = node.getRange().get();
     NodeList<AnnotationExpr> annotations = node.getAnnotations();
     AnnotationExpr annotationExpr = new MarkerAnnotationExpr(annotationSimpleName);
 

--- a/injector/src/main/java/edu/ucr/cs/riple/injector/changes/AddSingleElementAnnotation.java
+++ b/injector/src/main/java/edu/ucr/cs/riple/injector/changes/AddSingleElementAnnotation.java
@@ -31,6 +31,7 @@ import com.github.javaparser.ast.expr.Name;
 import com.github.javaparser.ast.expr.SingleMemberAnnotationExpr;
 import com.github.javaparser.ast.expr.StringLiteralExpr;
 import com.github.javaparser.ast.nodeTypes.NodeWithAnnotations;
+import com.github.javaparser.ast.nodeTypes.NodeWithRange;
 import com.google.common.base.Preconditions;
 import edu.ucr.cs.riple.injector.location.Location;
 import edu.ucr.cs.riple.injector.modifications.Insertion;
@@ -67,8 +68,11 @@ public class AddSingleElementAnnotation extends AddAnnotation {
 
   @Override
   @Nullable
-  public Modification visit(NodeWithAnnotations<?> node, Range range) {
-
+  public <T extends NodeWithAnnotations<?> & NodeWithRange<?>> Modification visit(T node) {
+    if (node.getRange().isEmpty()) {
+      return null;
+    }
+    Range range = node.getRange().get();
     StringLiteralExpr argumentExp = new StringLiteralExpr(argument);
     // Check all existing annotations with arguments.
     boolean argumentExists =

--- a/injector/src/main/java/edu/ucr/cs/riple/injector/changes/Change.java
+++ b/injector/src/main/java/edu/ucr/cs/riple/injector/changes/Change.java
@@ -22,9 +22,9 @@
 
 package edu.ucr.cs.riple.injector.changes;
 
-import com.github.javaparser.Range;
 import com.github.javaparser.ast.CompilationUnit;
 import com.github.javaparser.ast.nodeTypes.NodeWithAnnotations;
+import com.github.javaparser.ast.nodeTypes.NodeWithRange;
 import edu.ucr.cs.riple.injector.Helper;
 import edu.ucr.cs.riple.injector.location.Location;
 import edu.ucr.cs.riple.injector.modifications.Modification;
@@ -60,14 +60,14 @@ public abstract class Change {
   }
 
   /**
-   * Visits the given node and translates the change.
+   * Visits the given node and translates the change to a text modification.
    *
    * @param node Given node.
    * @return A text modification instance if the translation is successful, otherwise {@code null}
    *     will be returned.
    */
   @Nullable
-  public abstract Modification visit(NodeWithAnnotations<?> node, Range position);
+  public abstract <T extends NodeWithAnnotations<?> & NodeWithRange<?>> Modification visit(T node);
 
   @Override
   public boolean equals(Object o) {

--- a/injector/src/main/java/edu/ucr/cs/riple/injector/changes/RemoveAnnotation.java
+++ b/injector/src/main/java/edu/ucr/cs/riple/injector/changes/RemoveAnnotation.java
@@ -26,6 +26,7 @@ import com.github.javaparser.Range;
 import com.github.javaparser.ast.expr.AnnotationExpr;
 import com.github.javaparser.ast.expr.MarkerAnnotationExpr;
 import com.github.javaparser.ast.nodeTypes.NodeWithAnnotations;
+import com.github.javaparser.ast.nodeTypes.NodeWithRange;
 import edu.ucr.cs.riple.injector.location.Location;
 import edu.ucr.cs.riple.injector.modifications.Deletion;
 import edu.ucr.cs.riple.injector.modifications.Modification;
@@ -46,7 +47,7 @@ public class RemoveAnnotation extends Change {
 
   @Override
   @Nullable
-  public Modification visit(NodeWithAnnotations<?> node, Range range) {
+  public <T extends NodeWithAnnotations<?> & NodeWithRange<?>> Modification visit(T node) {
     // We only insert annotations with their simple name, therefore, we should only remove
     // the annotation if it matches with the simple name (otherwise, the annotation was not injected
     // by the core module request and should not be touched). Also, we currently require removing

--- a/injector/src/main/java/edu/ucr/cs/riple/injector/location/Location.java
+++ b/injector/src/main/java/edu/ucr/cs/riple/injector/location/Location.java
@@ -122,6 +122,7 @@ public abstract class Location {
    * @param change The change to be applied on the target element.
    * @return The modification that should be applied on the source file.
    */
+  @Nullable
   protected abstract Modification applyToMember(
       NodeList<BodyDeclaration<?>> members, Change change);
 
@@ -139,6 +140,7 @@ public abstract class Location {
    * @param change Change to be applied on the target element.
    * @return The modification that should be applied on the source file.
    */
+  @Nullable
   public Modification apply(CompilationUnit tree, Change change) {
     NodeList<BodyDeclaration<?>> clazz;
     try {

--- a/injector/src/main/java/edu/ucr/cs/riple/injector/location/OnClass.java
+++ b/injector/src/main/java/edu/ucr/cs/riple/injector/location/OnClass.java
@@ -27,13 +27,11 @@ package edu.ucr.cs.riple.injector.location;
 import com.github.javaparser.ast.Node;
 import com.github.javaparser.ast.NodeList;
 import com.github.javaparser.ast.body.BodyDeclaration;
-import com.github.javaparser.ast.nodeTypes.NodeWithAnnotations;
 import edu.ucr.cs.riple.injector.Helper;
 import edu.ucr.cs.riple.injector.changes.Change;
 import edu.ucr.cs.riple.injector.modifications.Modification;
 import java.nio.file.Path;
 import java.util.Optional;
-import java.util.concurrent.atomic.AtomicReference;
 import java.util.regex.Pattern;
 import org.json.simple.JSONObject;
 
@@ -59,13 +57,12 @@ public class OnClass extends Location {
     if (isAnonymousClassFlatName(change.location.clazz)) {
       return null;
     }
-    final AtomicReference<Modification> ans = new AtomicReference<>();
-    Optional<Node> clazz = members.getParentNode();
-    clazz.ifPresent(
-        node ->
-            node.getRange()
-                .ifPresent(range -> ans.set(change.visit((NodeWithAnnotations<?>) node, range))));
-    return ans.get();
+    // Get the enclosing class of the members
+    Optional<Node> optionalClass = members.getParentNode();
+    if (optionalClass.isEmpty() || !(optionalClass.get() instanceof BodyDeclaration<?>)) {
+      return null;
+    }
+    return change.visit(((BodyDeclaration<?>) optionalClass.get()));
   }
 
   /**

--- a/injector/src/main/java/edu/ucr/cs/riple/injector/location/OnField.java
+++ b/injector/src/main/java/edu/ucr/cs/riple/injector/location/OnField.java
@@ -24,7 +24,6 @@
 
 package edu.ucr.cs.riple.injector.location;
 
-import com.github.javaparser.Range;
 import com.github.javaparser.ast.NodeList;
 import com.github.javaparser.ast.body.BodyDeclaration;
 import com.github.javaparser.ast.body.VariableDeclarator;
@@ -34,7 +33,6 @@ import edu.ucr.cs.riple.injector.modifications.Modification;
 import java.nio.file.Path;
 import java.util.Collections;
 import java.util.Objects;
-import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Consumer;
@@ -92,8 +90,7 @@ public class OnField extends Location {
                       fieldDeclaration.asFieldDeclaration().getVariables();
                   for (VariableDeclarator v : vars) {
                     if (variables.contains(v.getName().toString())) {
-                      Optional<Range> range = fieldDeclaration.getRange();
-                      range.ifPresent(value -> ans.set(change.visit(fieldDeclaration, value)));
+                      ans.set(change.visit(fieldDeclaration));
                       break;
                     }
                   }

--- a/injector/src/main/java/edu/ucr/cs/riple/injector/location/OnMethod.java
+++ b/injector/src/main/java/edu/ucr/cs/riple/injector/location/OnMethod.java
@@ -78,7 +78,7 @@ public class OnMethod extends Location {
                   }
                   if (this.matcher.matchesCallableDeclaration(callableDeclaration)) {
                     Optional<Range> range = callableDeclaration.getRange();
-                    range.ifPresent(value -> ans.set(change.visit(callableDeclaration, value)));
+                    range.ifPresent(value -> ans.set(change.visit(callableDeclaration)));
                   }
                 }));
     if (ans.get() == null) {
@@ -89,9 +89,7 @@ public class OnMethod extends Location {
                     if (annotationMemberDeclaration
                         .getNameAsString()
                         .equals(Helper.extractCallableName(method))) {
-                      Optional<Range> range = annotationMemberDeclaration.getRange();
-                      range.ifPresent(
-                          value -> ans.set(change.visit(annotationMemberDeclaration, value)));
+                      ans.set(change.visit(annotationMemberDeclaration));
                     }
                   }));
     }

--- a/injector/src/main/java/edu/ucr/cs/riple/injector/location/OnMethod.java
+++ b/injector/src/main/java/edu/ucr/cs/riple/injector/location/OnMethod.java
@@ -24,7 +24,6 @@
 
 package edu.ucr.cs.riple.injector.location;
 
-import com.github.javaparser.Range;
 import com.github.javaparser.ast.NodeList;
 import com.github.javaparser.ast.body.BodyDeclaration;
 import edu.ucr.cs.riple.injector.Helper;
@@ -33,7 +32,6 @@ import edu.ucr.cs.riple.injector.changes.Change;
 import edu.ucr.cs.riple.injector.modifications.Modification;
 import java.nio.file.Path;
 import java.util.Objects;
-import java.util.Optional;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Consumer;
 import org.json.simple.JSONObject;
@@ -77,8 +75,7 @@ public class OnMethod extends Location {
                     return;
                   }
                   if (this.matcher.matchesCallableDeclaration(callableDeclaration)) {
-                    Optional<Range> range = callableDeclaration.getRange();
-                    range.ifPresent(value -> ans.set(change.visit(callableDeclaration)));
+                    ans.set(change.visit(callableDeclaration));
                   }
                 }));
     if (ans.get() == null) {

--- a/injector/src/main/java/edu/ucr/cs/riple/injector/location/OnParameter.java
+++ b/injector/src/main/java/edu/ucr/cs/riple/injector/location/OnParameter.java
@@ -24,19 +24,16 @@
 
 package edu.ucr.cs.riple.injector.location;
 
-import com.github.javaparser.Range;
 import com.github.javaparser.ast.Node;
 import com.github.javaparser.ast.NodeList;
 import com.github.javaparser.ast.body.BodyDeclaration;
 import com.github.javaparser.ast.body.Parameter;
-import com.github.javaparser.ast.nodeTypes.NodeWithAnnotations;
 import edu.ucr.cs.riple.injector.Helper;
 import edu.ucr.cs.riple.injector.SignatureMatcher;
 import edu.ucr.cs.riple.injector.changes.Change;
 import edu.ucr.cs.riple.injector.modifications.Modification;
 import java.nio.file.Path;
 import java.util.Objects;
-import java.util.Optional;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Consumer;
 import org.json.simple.JSONObject;
@@ -89,11 +86,11 @@ public class OnParameter extends Location {
                   if (matcher.matchesCallableDeclaration(callableDeclaration)) {
                     NodeList<?> params = callableDeclaration.getParameters();
                     if (index < params.size()) {
-                      if (params.get(index) instanceof Parameter) {
+                      if (params.get(index) != null) {
                         Node param = params.get(index);
-                        Optional<Range> range = param.getRange();
-                        range.ifPresent(
-                            value -> ans.set(change.visit((NodeWithAnnotations<?>) param, value)));
+                        if (param instanceof Parameter) {
+                          ans.set(change.visit((Parameter) param));
+                        }
                       }
                     }
                   }


### PR DESCRIPTION
This PR updates the method below:

```java
Modification visit(NodeWithAnnotations<?> node, Range range)
```
To
```java
<T extends NodeWithAnnotations<?> & NodeWithRange<?>> Modification visit(T node)
```

Since the value for `range` is retrievable from the class implementing `NodeWithAnnotations `, all calls to this method were as below:
```
visit(node, node.getRange)
```

With this update, all calls are changed to simply:
```
visit(node)
```