### PR TITLE
Javadoc update and add @Nullable annotations in Injector module

### DIFF
--- a/injector/src/main/java/edu/ucr/cs/riple/injector/changes/Change.java
+++ b/injector/src/main/java/edu/ucr/cs/riple/injector/changes/Change.java
@@ -60,7 +60,7 @@ public abstract class Change {
   }
 
   /**
-   * Visits the given node and translates the change.
+   * Visits the given node and translates the change to a text modification.
    *
    * @param node Given node.
    * @return A text modification instance if the translation is successful, otherwise {@code null}

--- a/injector/src/main/java/edu/ucr/cs/riple/injector/location/Location.java
+++ b/injector/src/main/java/edu/ucr/cs/riple/injector/location/Location.java
@@ -122,6 +122,7 @@ public abstract class Location {
    * @param change The change to be applied on the target element.
    * @return The modification that should be applied on the source file.
    */
+  @Nullable
   protected abstract Modification applyToMember(
       NodeList<BodyDeclaration<?>> members, Change change);
 
@@ -139,6 +140,7 @@ public abstract class Location {
    * @param change Change to be applied on the target element.
    * @return The modification that should be applied on the source file.
    */
+  @Nullable
   public Modification apply(CompilationUnit tree, Change change) {
     NodeList<BodyDeclaration<?>> clazz;
     try {

--- a/injector/src/main/java/edu/ucr/cs/riple/injector/location/OnClass.java
+++ b/injector/src/main/java/edu/ucr/cs/riple/injector/location/OnClass.java
@@ -35,6 +35,7 @@ import java.nio.file.Path;
 import java.util.Optional;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.regex.Pattern;
+import javax.annotation.Nullable;
 import org.json.simple.JSONObject;
 
 /** Represents a location for class element. This location is used to apply changes to a class. */
@@ -55,6 +56,7 @@ public class OnClass extends Location {
   }
 
   @Override
+  @Nullable
   protected Modification applyToMember(NodeList<BodyDeclaration<?>> members, Change change) {
     if (isAnonymousClassFlatName(change.location.clazz)) {
       return null;

--- a/injector/src/main/java/edu/ucr/cs/riple/injector/location/OnField.java
+++ b/injector/src/main/java/edu/ucr/cs/riple/injector/location/OnField.java
@@ -38,6 +38,7 @@ import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Consumer;
+import javax.annotation.Nullable;
 import org.json.simple.JSONArray;
 import org.json.simple.JSONObject;
 
@@ -78,6 +79,7 @@ public class OnField extends Location {
   }
 
   @Override
+  @Nullable
   protected Modification applyToMember(NodeList<BodyDeclaration<?>> members, Change change) {
     final AtomicReference<Modification> ans = new AtomicReference<>();
     members.forEach(

--- a/injector/src/main/java/edu/ucr/cs/riple/injector/location/OnMethod.java
+++ b/injector/src/main/java/edu/ucr/cs/riple/injector/location/OnMethod.java
@@ -36,6 +36,7 @@ import java.util.Objects;
 import java.util.Optional;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Consumer;
+import javax.annotation.Nullable;
 import org.json.simple.JSONObject;
 
 /** Represents a location for method element. This location is used to apply changes to a method. */
@@ -66,6 +67,7 @@ public class OnMethod extends Location {
   }
 
   @Override
+  @Nullable
   protected Modification applyToMember(NodeList<BodyDeclaration<?>> members, Change change) {
     final AtomicReference<Modification> ans = new AtomicReference<>();
     members.forEach(

--- a/injector/src/main/java/edu/ucr/cs/riple/injector/location/OnParameter.java
+++ b/injector/src/main/java/edu/ucr/cs/riple/injector/location/OnParameter.java
@@ -39,6 +39,7 @@ import java.util.Objects;
 import java.util.Optional;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Consumer;
+import javax.annotation.Nullable;
 import org.json.simple.JSONObject;
 
 /**
@@ -76,6 +77,7 @@ public class OnParameter extends Location {
   }
 
   @Override
+  @Nullable
   protected Modification applyToMember(NodeList<BodyDeclaration<?>> members, Change change) {
     final AtomicReference<Modification> ans = new AtomicReference<>();
     members.forEach(


### PR DESCRIPTION
This PR updates the javadoc comment for `visit` method in `Location` class. And also adds the required `@Nullable` annotations to `apply` methods and its overriding methods.