### PR TITLE
Rename MethodDeclarationTree to MethodRegistry

### DIFF
--- a/annotator-core/src/main/java/edu/ucr/cs/riple/core/cache/BaseCache.java
+++ b/annotator-core/src/main/java/edu/ucr/cs/riple/core/cache/BaseCache.java
@@ -48,7 +48,7 @@ public abstract class BaseCache<T extends Impact, S extends Map<Location, T>>
   protected final S store;
   /** Annotator config. */
   protected final Config config;
-  /** Method declaration tree to store target module structure. */
+  /** Method registry to store records of declared methods in target module. */
   protected final MethodRegistry methodRegistry;
 
   public BaseCache(Config config, S store, MethodRegistry methodRegistry) {

--- a/annotator-core/src/main/java/edu/ucr/cs/riple/core/cache/BaseCache.java
+++ b/annotator-core/src/main/java/edu/ucr/cs/riple/core/cache/BaseCache.java
@@ -28,7 +28,7 @@ import com.google.common.collect.ImmutableSet;
 import edu.ucr.cs.riple.core.Config;
 import edu.ucr.cs.riple.core.metadata.index.Error;
 import edu.ucr.cs.riple.core.metadata.index.Fix;
-import edu.ucr.cs.riple.core.metadata.method.MethodDeclarationTree;
+import edu.ucr.cs.riple.core.metadata.method.MethodRegistry;
 import edu.ucr.cs.riple.injector.location.Location;
 import java.util.Collection;
 import java.util.Map;
@@ -49,12 +49,12 @@ public abstract class BaseCache<T extends Impact, S extends Map<Location, T>>
   /** Annotator config. */
   protected final Config config;
   /** Method declaration tree to store target module structure. */
-  protected final MethodDeclarationTree tree;
+  protected final MethodRegistry methodRegistry;
 
-  public BaseCache(Config config, S store, MethodDeclarationTree tree) {
+  public BaseCache(Config config, S store, MethodRegistry methodRegistry) {
     this.store = store;
     this.config = config;
-    this.tree = tree;
+    this.methodRegistry = methodRegistry;
   }
 
   @Override

--- a/annotator-core/src/main/java/edu/ucr/cs/riple/core/cache/TargetModuleCache.java
+++ b/annotator-core/src/main/java/edu/ucr/cs/riple/core/cache/TargetModuleCache.java
@@ -25,7 +25,7 @@
 package edu.ucr.cs.riple.core.cache;
 
 import edu.ucr.cs.riple.core.Config;
-import edu.ucr.cs.riple.core.metadata.method.MethodDeclarationTree;
+import edu.ucr.cs.riple.core.metadata.method.MethodRegistry;
 import edu.ucr.cs.riple.injector.location.Location;
 import java.util.HashMap;
 import java.util.Set;
@@ -36,8 +36,8 @@ import java.util.Set;
  */
 public class TargetModuleCache extends BaseCache<Impact, HashMap<Location, Impact>> {
 
-  public TargetModuleCache(Config config, MethodDeclarationTree tree) {
-    super(config, new HashMap<>(), tree);
+  public TargetModuleCache(Config config, MethodRegistry registry) {
+    super(config, new HashMap<>(), registry);
   }
 
   /**

--- a/annotator-core/src/main/java/edu/ucr/cs/riple/core/cache/downstream/DownstreamImpact.java
+++ b/annotator-core/src/main/java/edu/ucr/cs/riple/core/cache/downstream/DownstreamImpact.java
@@ -31,7 +31,7 @@ import edu.ucr.cs.riple.core.Report;
 import edu.ucr.cs.riple.core.cache.Impact;
 import edu.ucr.cs.riple.core.metadata.index.Error;
 import edu.ucr.cs.riple.core.metadata.index.Fix;
-import edu.ucr.cs.riple.core.metadata.method.MethodNode;
+import edu.ucr.cs.riple.core.metadata.method.MethodRecord;
 import edu.ucr.cs.riple.injector.location.OnMethod;
 import edu.ucr.cs.riple.injector.location.OnParameter;
 import java.util.Collection;
@@ -105,7 +105,7 @@ public class DownstreamImpact extends Impact {
    * @return Expected hash.
    */
   public static int hash(String method, String clazz) {
-    return MethodNode.hash(method, clazz);
+    return MethodRecord.hash(method, clazz);
   }
 
   /**

--- a/annotator-core/src/main/java/edu/ucr/cs/riple/core/cache/downstream/DownstreamImpactCacheImpl.java
+++ b/annotator-core/src/main/java/edu/ucr/cs/riple/core/cache/downstream/DownstreamImpactCacheImpl.java
@@ -67,8 +67,8 @@ public class DownstreamImpactCacheImpl
    * computed once {@link #analyzeDownstreamDependencies()} is called.
    *
    * @param config Annotator config.
-   * @param registry Method declaration registry for target module used to collect public methods
-   *     with non-primitive return types to compute their impacts on downstream dependencies.
+   * @param registry Method registry for target module used to collect public methods with
+   *     non-primitive return types to compute their impacts on downstream dependencies.
    */
   public DownstreamImpactCacheImpl(Config config, MethodRegistry registry) {
     super(

--- a/annotator-core/src/main/java/edu/ucr/cs/riple/core/cache/downstream/DownstreamImpactEvaluator.java
+++ b/annotator-core/src/main/java/edu/ucr/cs/riple/core/cache/downstream/DownstreamImpactEvaluator.java
@@ -29,7 +29,7 @@ import edu.ucr.cs.riple.core.Report;
 import edu.ucr.cs.riple.core.evaluators.BasicEvaluator;
 import edu.ucr.cs.riple.core.evaluators.suppliers.DownstreamDependencySupplier;
 import edu.ucr.cs.riple.core.metadata.index.Error;
-import edu.ucr.cs.riple.core.metadata.method.MethodDeclarationTree;
+import edu.ucr.cs.riple.core.metadata.method.MethodRegistry;
 import edu.ucr.cs.riple.injector.location.OnMethod;
 import edu.ucr.cs.riple.injector.location.OnParameter;
 import java.util.Collections;
@@ -51,12 +51,12 @@ class DownstreamImpactEvaluator extends BasicEvaluator {
    */
   private final HashMap<OnMethod, Set<OnParameter>> nullableFlowMap;
 
-  private final MethodDeclarationTree methodDeclarationTree;
+  private final MethodRegistry methodRegistry;
 
   public DownstreamImpactEvaluator(DownstreamDependencySupplier supplier) {
     super(supplier);
     this.nullableFlowMap = new HashMap<>();
-    this.methodDeclarationTree = supplier.getMethodDeclarationTree();
+    this.methodRegistry = supplier.getMethodRegistry();
   }
 
   @Override
@@ -77,7 +77,7 @@ class DownstreamImpactEvaluator extends BasicEvaluator {
                                       error.isSingleFix()
                                           && error.toResolvingLocation().isOnParameter()
                                           // Method is declared in the target module.
-                                          && methodDeclarationTree.declaredInModule(
+                                          && methodRegistry.declaredInModule(
                                               error.toResolvingParameter()))
                               .map(Error::toResolvingParameter)
                               .collect(Collectors.toSet());
@@ -88,8 +88,7 @@ class DownstreamImpactEvaluator extends BasicEvaluator {
                         parameters.forEach(
                             onParameter ->
                                 onParameter.path =
-                                    methodDeclarationTree.findNode(
-                                            onParameter.method, onParameter.clazz)
+                                    methodRegistry.findNode(onParameter.method, onParameter.clazz)
                                         .location
                                         .path);
                         nullableFlowMap.put(method, parameters);

--- a/annotator-core/src/main/java/edu/ucr/cs/riple/core/evaluators/graphprocessor/AbstractConflictGraphProcessor.java
+++ b/annotator-core/src/main/java/edu/ucr/cs/riple/core/evaluators/graphprocessor/AbstractConflictGraphProcessor.java
@@ -31,7 +31,7 @@ import edu.ucr.cs.riple.core.injectors.AnnotationInjector;
 import edu.ucr.cs.riple.core.metadata.graph.Node;
 import edu.ucr.cs.riple.core.metadata.index.ErrorStore;
 import edu.ucr.cs.riple.core.metadata.index.Fix;
-import edu.ucr.cs.riple.core.metadata.method.MethodDeclarationTree;
+import edu.ucr.cs.riple.core.metadata.method.MethodRegistry;
 import edu.ucr.cs.riple.injector.changes.AddMarkerAnnotation;
 import edu.ucr.cs.riple.injector.location.Location;
 import java.util.Set;
@@ -41,7 +41,7 @@ import java.util.stream.Collectors;
 public abstract class AbstractConflictGraphProcessor implements ConflictGraphProcessor {
 
   /** Method declaration tree. */
-  protected final MethodDeclarationTree methodDeclarationTree;
+  protected final MethodRegistry methodRegistry;
   /** Injector used in the processor to inject / remove fixes. */
   protected final AnnotationInjector injector;
   /** Error store instance to store state of fixes before and after of injections. */
@@ -55,7 +55,7 @@ public abstract class AbstractConflictGraphProcessor implements ConflictGraphPro
 
   public AbstractConflictGraphProcessor(Config config, CompilerRunner runner, Supplier supplier) {
     this.config = config;
-    this.methodDeclarationTree = supplier.getMethodDeclarationTree();
+    this.methodRegistry = supplier.getMethodRegistry();
     this.injector = supplier.getInjector();
     this.downstreamImpactCache = supplier.getDownstreamImpactCache();
     this.errorStore = supplier.getErrorStore();
@@ -75,7 +75,7 @@ public abstract class AbstractConflictGraphProcessor implements ConflictGraphPro
             error ->
                 error.isSingleFix()
                     && error.toResolvingLocation().isOnParameter()
-                    && error.isFixableOnTarget(methodDeclarationTree)
+                    && error.isFixableOnTarget(methodRegistry)
                     && !currentLocationsTargetedByTree.contains(error.toResolvingLocation()))
         .map(
             error ->

--- a/annotator-core/src/main/java/edu/ucr/cs/riple/core/evaluators/graphprocessor/AbstractConflictGraphProcessor.java
+++ b/annotator-core/src/main/java/edu/ucr/cs/riple/core/evaluators/graphprocessor/AbstractConflictGraphProcessor.java
@@ -40,7 +40,7 @@ import java.util.stream.Collectors;
 /** Base class for conflict graph processors. */
 public abstract class AbstractConflictGraphProcessor implements ConflictGraphProcessor {
 
-  /** Method declaration tree. */
+  /** Method registry used to keep records of declared methods in target module. */
   protected final MethodRegistry methodRegistry;
   /** Injector used in the processor to inject / remove fixes. */
   protected final AnnotationInjector injector;

--- a/annotator-core/src/main/java/edu/ucr/cs/riple/core/evaluators/graphprocessor/ParallelConflictGraphProcessor.java
+++ b/annotator-core/src/main/java/edu/ucr/cs/riple/core/evaluators/graphprocessor/ParallelConflictGraphProcessor.java
@@ -90,7 +90,7 @@ public class ParallelConflictGraphProcessor extends AbstractConflictGraphProcess
                 fixes,
                 getTriggeredFixesFromDownstreamErrors(node),
                 triggeredErrors,
-                methodDeclarationTree);
+                methodRegistry);
           });
       injector.removeFixes(fixes);
     }

--- a/annotator-core/src/main/java/edu/ucr/cs/riple/core/evaluators/graphprocessor/SequentialConflictGraphProcessor.java
+++ b/annotator-core/src/main/java/edu/ucr/cs/riple/core/evaluators/graphprocessor/SequentialConflictGraphProcessor.java
@@ -61,7 +61,7 @@ public class SequentialConflictGraphProcessor extends AbstractConflictGraphProce
                   fixes,
                   getTriggeredFixesFromDownstreamErrors(node),
                   errorComparisonResult.dif,
-                  methodDeclarationTree);
+                  methodRegistry);
               injector.removeFixes(fixes);
             });
     pb.close();

--- a/annotator-core/src/main/java/edu/ucr/cs/riple/core/evaluators/suppliers/AbstractSupplier.java
+++ b/annotator-core/src/main/java/edu/ucr/cs/riple/core/evaluators/suppliers/AbstractSupplier.java
@@ -40,7 +40,7 @@ public abstract class AbstractSupplier implements Supplier {
   protected final ErrorStore errorStore;
   /** Injector instance. */
   protected final AnnotationInjector injector;
-  /** Method declaration tree instance. */
+  /** Method registry instance. */
   protected final MethodRegistry methodRegistry;
   /** Depth of analysis. */
   protected final int depth;

--- a/annotator-core/src/main/java/edu/ucr/cs/riple/core/evaluators/suppliers/AbstractSupplier.java
+++ b/annotator-core/src/main/java/edu/ucr/cs/riple/core/evaluators/suppliers/AbstractSupplier.java
@@ -31,7 +31,7 @@ import edu.ucr.cs.riple.core.injectors.AnnotationInjector;
 import edu.ucr.cs.riple.core.metadata.field.FieldDeclarationStore;
 import edu.ucr.cs.riple.core.metadata.index.Error;
 import edu.ucr.cs.riple.core.metadata.index.ErrorStore;
-import edu.ucr.cs.riple.core.metadata.method.MethodDeclarationTree;
+import edu.ucr.cs.riple.core.metadata.method.MethodRegistry;
 
 /** Base class for all instances of {@link Supplier}. */
 public abstract class AbstractSupplier implements Supplier {
@@ -41,7 +41,7 @@ public abstract class AbstractSupplier implements Supplier {
   /** Injector instance. */
   protected final AnnotationInjector injector;
   /** Method declaration tree instance. */
-  protected final MethodDeclarationTree tree;
+  protected final MethodRegistry methodRegistry;
   /** Depth of analysis. */
   protected final int depth;
   /** Field declaration analysis to detect fixes on inline multiple field declaration statements. */
@@ -50,10 +50,10 @@ public abstract class AbstractSupplier implements Supplier {
   protected final Config config;
 
   public AbstractSupplier(
-      ImmutableSet<ModuleInfo> modules, Config config, MethodDeclarationTree tree) {
+      ImmutableSet<ModuleInfo> modules, Config config, MethodRegistry registry) {
     this.config = config;
     this.fieldDeclarationStore = new FieldDeclarationStore(config, modules);
-    this.tree = tree;
+    this.methodRegistry = registry;
     this.errorStore = initializeErrorStore(modules);
     this.injector = initializeInjector();
     this.depth = initializeDepth();
@@ -98,8 +98,8 @@ public abstract class AbstractSupplier implements Supplier {
   }
 
   @Override
-  public MethodDeclarationTree getMethodDeclarationTree() {
-    return tree;
+  public MethodRegistry getMethodRegistry() {
+    return methodRegistry;
   }
 
   @Override

--- a/annotator-core/src/main/java/edu/ucr/cs/riple/core/evaluators/suppliers/DownstreamDependencySupplier.java
+++ b/annotator-core/src/main/java/edu/ucr/cs/riple/core/evaluators/suppliers/DownstreamDependencySupplier.java
@@ -34,7 +34,7 @@ import edu.ucr.cs.riple.core.evaluators.graphprocessor.ParallelConflictGraphProc
 import edu.ucr.cs.riple.core.evaluators.graphprocessor.SequentialConflictGraphProcessor;
 import edu.ucr.cs.riple.core.injectors.AnnotationInjector;
 import edu.ucr.cs.riple.core.injectors.VirtualInjector;
-import edu.ucr.cs.riple.core.metadata.method.MethodDeclarationTree;
+import edu.ucr.cs.riple.core.metadata.method.MethodRegistry;
 import edu.ucr.cs.riple.core.metadata.trackers.RegionTracker;
 import edu.ucr.cs.riple.core.util.Utility;
 
@@ -52,8 +52,8 @@ public class DownstreamDependencySupplier extends AbstractSupplier {
   private final RegionTracker tracker;
 
   public DownstreamDependencySupplier(
-      Config config, RegionTracker tracker, MethodDeclarationTree tree) {
-    super(config.downstreamInfo, config, tree);
+      Config config, RegionTracker tracker, MethodRegistry registry) {
+    super(config.downstreamInfo, config, registry);
     this.tracker = tracker;
   }
 

--- a/annotator-core/src/main/java/edu/ucr/cs/riple/core/evaluators/suppliers/Supplier.java
+++ b/annotator-core/src/main/java/edu/ucr/cs/riple/core/evaluators/suppliers/Supplier.java
@@ -32,7 +32,7 @@ import edu.ucr.cs.riple.core.evaluators.graphprocessor.ConflictGraphProcessor;
 import edu.ucr.cs.riple.core.injectors.AnnotationInjector;
 import edu.ucr.cs.riple.core.metadata.index.Error;
 import edu.ucr.cs.riple.core.metadata.index.ErrorStore;
-import edu.ucr.cs.riple.core.metadata.method.MethodDeclarationTree;
+import edu.ucr.cs.riple.core.metadata.method.MethodRegistry;
 
 /** Supplier for initializing an {@link AbstractEvaluator} instance. */
 public interface Supplier {
@@ -52,11 +52,11 @@ public interface Supplier {
   AnnotationInjector getInjector();
 
   /**
-   * Getter for {@link MethodDeclarationTree} instance.
+   * Getter for {@link MethodRegistry} instance.
    *
-   * @return MethodDeclarationTree instance.
+   * @return MethodRegistry instance.
    */
-  MethodDeclarationTree getMethodDeclarationTree();
+  MethodRegistry getMethodRegistry();
 
   /**
    * Getter for depth of analysis.

--- a/annotator-core/src/main/java/edu/ucr/cs/riple/core/evaluators/suppliers/TargetModuleSupplier.java
+++ b/annotator-core/src/main/java/edu/ucr/cs/riple/core/evaluators/suppliers/TargetModuleSupplier.java
@@ -34,7 +34,7 @@ import edu.ucr.cs.riple.core.evaluators.graphprocessor.ParallelConflictGraphProc
 import edu.ucr.cs.riple.core.evaluators.graphprocessor.SequentialConflictGraphProcessor;
 import edu.ucr.cs.riple.core.injectors.AnnotationInjector;
 import edu.ucr.cs.riple.core.injectors.PhysicalInjector;
-import edu.ucr.cs.riple.core.metadata.method.MethodDeclarationTree;
+import edu.ucr.cs.riple.core.metadata.method.MethodRegistry;
 import edu.ucr.cs.riple.core.metadata.trackers.CompoundTracker;
 import edu.ucr.cs.riple.core.metadata.trackers.RegionTracker;
 import edu.ucr.cs.riple.core.util.Utility;
@@ -59,14 +59,14 @@ public class TargetModuleSupplier extends AbstractSupplier {
    * @param config Annotator config instance.
    * @param targetModuleCache Target module impact cache instance.
    * @param downstreamImpactCache Downstream impact cache instance.
-   * @param tree Method declaration tree for methods in target module.
+   * @param registry Method declaration registry for methods in target module.
    */
   public TargetModuleSupplier(
       Config config,
       TargetModuleCache targetModuleCache,
       DownstreamImpactCache downstreamImpactCache,
-      MethodDeclarationTree tree) {
-    super(ImmutableSet.of(config.target), config, tree);
+      MethodRegistry registry) {
+    super(ImmutableSet.of(config.target), config, registry);
     this.downstreamImpactCache = downstreamImpactCache;
     this.targetModuleCache = targetModuleCache;
   }
@@ -91,7 +91,7 @@ public class TargetModuleSupplier extends AbstractSupplier {
     CompilerRunner runner = () -> Utility.buildTarget(config);
     if (config.useParallelGraphProcessor) {
       RegionTracker tracker =
-          new CompoundTracker(config, config.target, tree, fieldDeclarationStore);
+          new CompoundTracker(config, config.target, methodRegistry, fieldDeclarationStore);
       return new ParallelConflictGraphProcessor(config, runner, this, tracker);
     }
     return new SequentialConflictGraphProcessor(config, runner, this);

--- a/annotator-core/src/main/java/edu/ucr/cs/riple/core/evaluators/suppliers/TargetModuleSupplier.java
+++ b/annotator-core/src/main/java/edu/ucr/cs/riple/core/evaluators/suppliers/TargetModuleSupplier.java
@@ -59,7 +59,7 @@ public class TargetModuleSupplier extends AbstractSupplier {
    * @param config Annotator config instance.
    * @param targetModuleCache Target module impact cache instance.
    * @param downstreamImpactCache Downstream impact cache instance.
-   * @param registry Method declaration registry for methods in target module.
+   * @param registry Method registry for methods in target module.
    */
   public TargetModuleSupplier(
       Config config,

--- a/annotator-core/src/main/java/edu/ucr/cs/riple/core/metadata/graph/Node.java
+++ b/annotator-core/src/main/java/edu/ucr/cs/riple/core/metadata/graph/Node.java
@@ -140,7 +140,7 @@ public class Node {
    * @param fixesInOneRound All fixes applied simultaneously to the source code.
    * @param triggeredFixesFromDownstreamErrors Triggered fixes from downstream dependencies.
    * @param triggeredErrors Triggered Errors collected from impacted regions.
-   * @param registry Method declaration tree instance.
+   * @param registry Method registry instance.
    */
   public void updateStatus(
       int localEffect,

--- a/annotator-core/src/main/java/edu/ucr/cs/riple/core/metadata/graph/Node.java
+++ b/annotator-core/src/main/java/edu/ucr/cs/riple/core/metadata/graph/Node.java
@@ -30,7 +30,7 @@ import edu.ucr.cs.riple.core.Report;
 import edu.ucr.cs.riple.core.metadata.index.Error;
 import edu.ucr.cs.riple.core.metadata.index.ErrorStore;
 import edu.ucr.cs.riple.core.metadata.index.Fix;
-import edu.ucr.cs.riple.core.metadata.method.MethodDeclarationTree;
+import edu.ucr.cs.riple.core.metadata.method.MethodRegistry;
 import edu.ucr.cs.riple.core.metadata.trackers.Region;
 import edu.ucr.cs.riple.core.metadata.trackers.RegionTracker;
 import edu.ucr.cs.riple.injector.location.OnMethod;
@@ -140,14 +140,14 @@ public class Node {
    * @param fixesInOneRound All fixes applied simultaneously to the source code.
    * @param triggeredFixesFromDownstreamErrors Triggered fixes from downstream dependencies.
    * @param triggeredErrors Triggered Errors collected from impacted regions.
-   * @param mdt Method declaration tree instance.
+   * @param registry Method declaration tree instance.
    */
   public void updateStatus(
       int localEffect,
       Set<Fix> fixesInOneRound,
       Collection<Fix> triggeredFixesFromDownstreamErrors,
       Collection<Error> triggeredErrors,
-      MethodDeclarationTree mdt) {
+      MethodRegistry registry) {
     // Update list of triggered fixes on downstream.
     this.triggeredFixesFromDownstreamErrors =
         ImmutableSet.copyOf(triggeredFixesFromDownstreamErrors);
@@ -162,7 +162,7 @@ public class Node {
         .map(
             fix -> {
               OnMethod onMethod = fix.toMethod();
-              return mdt.getClosestSuperMethod(onMethod.method, onMethod.clazz);
+              return registry.getClosestSuperMethod(onMethod.method, onMethod.clazz);
             }) // Collection of super methods of all fixes in tree.
         .filter(
             node ->

--- a/annotator-core/src/main/java/edu/ucr/cs/riple/core/metadata/index/Error.java
+++ b/annotator-core/src/main/java/edu/ucr/cs/riple/core/metadata/index/Error.java
@@ -192,7 +192,7 @@ public class Error {
    * Checks if error is resolvable and all suggested fixes must be applied to an element in target
    * module.
    *
-   * @param registry Method declaration registry to check if elements on are on target.
+   * @param registry Method registry to check if elements on are on target.
    * @return true, if error is resolvable via fixes on target module.
    */
   public boolean isFixableOnTarget(MethodRegistry registry) {

--- a/annotator-core/src/main/java/edu/ucr/cs/riple/core/metadata/index/Error.java
+++ b/annotator-core/src/main/java/edu/ucr/cs/riple/core/metadata/index/Error.java
@@ -27,7 +27,7 @@ import com.google.common.base.Preconditions;
 import com.google.common.collect.ImmutableSet;
 import edu.ucr.cs.riple.core.Config;
 import edu.ucr.cs.riple.core.metadata.field.FieldDeclarationStore;
-import edu.ucr.cs.riple.core.metadata.method.MethodDeclarationTree;
+import edu.ucr.cs.riple.core.metadata.method.MethodRegistry;
 import edu.ucr.cs.riple.core.metadata.trackers.Region;
 import edu.ucr.cs.riple.injector.location.Location;
 import edu.ucr.cs.riple.injector.location.OnParameter;
@@ -192,12 +192,13 @@ public class Error {
    * Checks if error is resolvable and all suggested fixes must be applied to an element in target
    * module.
    *
-   * @param tree Method declaration tree to check if elements on are on target.
+   * @param registry Method declaration registry to check if elements on are on target.
    * @return true, if error is resolvable via fixes on target module.
    */
-  public boolean isFixableOnTarget(MethodDeclarationTree tree) {
+  public boolean isFixableOnTarget(MethodRegistry registry) {
     return resolvingFixes.size() > 0
-        && this.resolvingFixes.stream().allMatch(fix -> tree.declaredInModule(fix.toLocation()));
+        && this.resolvingFixes.stream()
+            .allMatch(fix -> registry.declaredInModule(fix.toLocation()));
   }
 
   @Override

--- a/annotator-core/src/main/java/edu/ucr/cs/riple/core/metadata/method/MethodRecord.java
+++ b/annotator-core/src/main/java/edu/ucr/cs/riple/core/metadata/method/MethodRecord.java
@@ -29,8 +29,8 @@ import java.util.HashSet;
 import java.util.Objects;
 import java.util.Set;
 
-/** Container class to store method's information in {@link MethodDeclarationTree} tree. */
-public class MethodNode {
+/** Container class to store method's information in {@link MethodRegistry} tree. */
+public class MethodRecord {
 
   /** Set of children's id. */
   public Set<Integer> children;
@@ -50,7 +50,7 @@ public class MethodNode {
   /** Is true if the method is a constructor. */
   public boolean isConstructor;
 
-  public static final MethodNode TOP = top();
+  public static final MethodRecord TOP = top();
 
   /** Visibility of method. */
   public enum Visibility {
@@ -65,17 +65,17 @@ public class MethodNode {
      * @param value Visibility value in string.
      * @return Corresponding visibility instance.
      */
-    public static MethodNode.Visibility parse(String value) {
+    public static MethodRecord.Visibility parse(String value) {
       String toLower = value.toLowerCase();
       switch (toLower) {
         case "public":
-          return MethodNode.Visibility.PUBLIC;
+          return MethodRecord.Visibility.PUBLIC;
         case "private":
-          return MethodNode.Visibility.PRIVATE;
+          return MethodRecord.Visibility.PRIVATE;
         case "protected":
-          return MethodNode.Visibility.PROTECTED;
+          return MethodRecord.Visibility.PROTECTED;
         case "package":
-          return MethodNode.Visibility.PACKAGE;
+          return MethodRecord.Visibility.PACKAGE;
         default:
           throw new IllegalArgumentException("Unknown visibility type: " + value);
       }
@@ -83,14 +83,13 @@ public class MethodNode {
   }
 
   /**
-   * Creates a singleton instance of top object. Top is root of the {@link MethodDeclarationTree}
-   * tree.
+   * Creates a singleton instance of top object. Top is root of the {@link MethodRegistry} tree.
    *
    * @return The top Node.
    */
-  private static MethodNode top() {
+  private static MethodRecord top() {
     if (TOP == null) {
-      MethodNode node = new MethodNode(0);
+      MethodRecord node = new MethodRecord(0);
       node.fillInformation(null, -1, false, "private", false, false);
       return node;
     }
@@ -98,11 +97,11 @@ public class MethodNode {
   }
 
   /**
-   * Creates a MethodNode with a unique id.
+   * Creates a MethodRecord with a unique id.
    *
    * @param id A unique id.
    */
-  public MethodNode(int id) {
+  public MethodRecord(int id) {
     this.id = id;
   }
 
@@ -153,7 +152,7 @@ public class MethodNode {
    * @return true if method is public with non-primitive return type and false otherwise.
    */
   public boolean isPublicMethodWithNonPrimitiveReturnType() {
-    return hasNonPrimitiveReturn && visibility.equals(MethodNode.Visibility.PUBLIC);
+    return hasNonPrimitiveReturn && visibility.equals(MethodRecord.Visibility.PUBLIC);
   }
 
   @Override
@@ -161,10 +160,10 @@ public class MethodNode {
     if (this == o) {
       return true;
     }
-    if (!(o instanceof MethodNode)) {
+    if (!(o instanceof MethodRecord)) {
       return false;
     }
-    MethodNode that = (MethodNode) o;
+    MethodRecord that = (MethodRecord) o;
     return Objects.equals(children, that.children)
         && Objects.equals(parent, that.parent)
         && Objects.equals(id, that.id)

--- a/annotator-core/src/main/java/edu/ucr/cs/riple/core/metadata/method/MethodRegistry.java
+++ b/annotator-core/src/main/java/edu/ucr/cs/riple/core/metadata/method/MethodRegistry.java
@@ -131,7 +131,8 @@ public class MethodRegistry extends MetaData<MethodRecord> {
    *
    * @param method Method signature of input.
    * @param clazz Fully qualified name of the input method.
-   * @param recursive If ture, it will travers the declaration tree recursively.
+   * @param recursive If ture, it will traverse the registry recursively will include all overriding
+   *     methods.
    * @return ImmutableSet of overriding methods.
    */
   public ImmutableSet<MethodRecord> getSubMethods(String method, String clazz, boolean recursive) {

--- a/annotator-core/src/main/java/edu/ucr/cs/riple/core/metadata/method/MethodRegistry.java
+++ b/annotator-core/src/main/java/edu/ucr/cs/riple/core/metadata/method/MethodRegistry.java
@@ -42,17 +42,17 @@ import javax.annotation.Nullable;
  * The top-down tree structure of methods in the target module, where each method's parent node, is
  * their immediate overriding method.
  */
-public class MethodDeclarationTree extends MetaData<MethodNode> {
+public class MethodRegistry extends MetaData<MethodRecord> {
 
   /** Each method has a unique id across all methods. This hashmap, maps ids to nodes. */
-  private HashMap<Integer, MethodNode> nodes;
+  private HashMap<Integer, MethodRecord> nodes;
 
   /** A map from class flat name to its declared constructors */
-  private Multimap<String, MethodNode> classConstructorMap;
+  private Multimap<String, MethodRecord> classConstructorMap;
   /** Set of all classes flat name declared in module. */
   private Set<String> declaredClasses;
 
-  public MethodDeclarationTree(Config config) {
+  public MethodRegistry(Config config) {
     super(config, config.target.dir.resolve(Serializer.METHOD_INFO_FILE_NAME));
   }
 
@@ -63,18 +63,18 @@ public class MethodDeclarationTree extends MetaData<MethodNode> {
     this.classConstructorMap = MultimapBuilder.hashKeys().hashSetValues().build();
     this.nodes = new HashMap<>();
     // The root node of this tree with id: 0.
-    nodes.put(MethodNode.TOP.id, MethodNode.TOP);
+    nodes.put(MethodRecord.TOP.id, MethodRecord.TOP);
   }
 
   @Override
-  protected MethodNode addNodeByLine(String[] values) {
+  protected MethodRecord addNodeByLine(String[] values) {
     // Nodes unique id.
     Integer id = Integer.parseInt(values[0]);
-    MethodNode node;
+    MethodRecord node;
     if (nodes.containsKey(id)) {
       node = nodes.get(id);
     } else {
-      node = new MethodNode(id);
+      node = new MethodRecord(id);
       nodes.put(id, node);
     }
     // Fill nodes information.
@@ -91,10 +91,10 @@ public class MethodDeclarationTree extends MetaData<MethodNode> {
         isConstructor);
     // If node has a non-top parent.
     if (parentId > 0) {
-      MethodNode parent = nodes.get(parentId);
+      MethodRecord parent = nodes.get(parentId);
       // If parent has not been seen visited before.
       if (parent == null) {
-        parent = new MethodNode(parentId);
+        parent = new MethodRecord(parentId);
         nodes.put(parentId, parent);
       }
       // Parent is already visited.
@@ -117,12 +117,12 @@ public class MethodDeclarationTree extends MetaData<MethodNode> {
    * @return Corresponding node of the overridden method, null if method has no parent.
    */
   @Nullable
-  public MethodNode getClosestSuperMethod(String method, String clazz) {
-    MethodNode node = findNode(method, clazz);
+  public MethodRecord getClosestSuperMethod(String method, String clazz) {
+    MethodRecord node = findNode(method, clazz);
     if (node == null) {
       return null;
     }
-    MethodNode parent = nodes.get(node.parent);
+    MethodRecord parent = nodes.get(node.parent);
     return (parent.isNonTop() && parent.location != null) ? parent : null;
   }
 
@@ -134,20 +134,20 @@ public class MethodDeclarationTree extends MetaData<MethodNode> {
    * @param recursive If ture, it will travers the declaration tree recursively.
    * @return ImmutableSet of overriding methods.
    */
-  public ImmutableSet<MethodNode> getSubMethods(String method, String clazz, boolean recursive) {
-    MethodNode node = findNode(method, clazz);
+  public ImmutableSet<MethodRecord> getSubMethods(String method, String clazz, boolean recursive) {
+    MethodRecord node = findNode(method, clazz);
     if (node == null) {
       return ImmutableSet.of();
     }
     if (node.children == null) {
       return ImmutableSet.of();
     }
-    Set<MethodNode> ans = new HashSet<>();
+    Set<MethodRecord> ans = new HashSet<>();
     Set<Integer> workList = new HashSet<>(node.children);
     while (!workList.isEmpty()) {
       Set<Integer> tmp = new HashSet<>();
       for (Integer id : workList) {
-        MethodNode selected = nodes.get(id);
+        MethodRecord selected = nodes.get(id);
         if (!ans.contains(selected)) {
           ans.add(selected);
           if (selected.children != null) {
@@ -171,11 +171,11 @@ public class MethodDeclarationTree extends MetaData<MethodNode> {
    * @param clazz Fully Qualified name of the class.
    * @return Corresponding node.
    */
-  public MethodNode findNode(String method, String clazz) {
+  public MethodRecord findNode(String method, String clazz) {
     return findNodeWithHashHint(
         candidate ->
             candidate.location.clazz.equals(clazz) && candidate.location.method.equals(method),
-        MethodNode.hash(method, clazz));
+        MethodRecord.hash(method, clazz));
   }
 
   /**
@@ -183,8 +183,8 @@ public class MethodDeclarationTree extends MetaData<MethodNode> {
    *
    * @return ImmutableSet of method nodes.
    */
-  public ImmutableSet<MethodNode> getPublicMethodsWithNonPrimitivesReturn() {
-    return findNodes(MethodNode::isPublicMethodWithNonPrimitiveReturnType)
+  public ImmutableSet<MethodRecord> getPublicMethodsWithNonPrimitivesReturn() {
+    return findNodes(MethodRecord::isPublicMethodWithNonPrimitiveReturnType)
         .collect(ImmutableSet.toImmutableSet());
   }
 

--- a/annotator-core/src/main/java/edu/ucr/cs/riple/core/metadata/trackers/CompoundTracker.java
+++ b/annotator-core/src/main/java/edu/ucr/cs/riple/core/metadata/trackers/CompoundTracker.java
@@ -28,7 +28,7 @@ import com.google.common.collect.ImmutableSet;
 import edu.ucr.cs.riple.core.Config;
 import edu.ucr.cs.riple.core.ModuleInfo;
 import edu.ucr.cs.riple.core.metadata.field.FieldDeclarationStore;
-import edu.ucr.cs.riple.core.metadata.method.MethodDeclarationTree;
+import edu.ucr.cs.riple.core.metadata.method.MethodRegistry;
 import edu.ucr.cs.riple.core.metadata.trackers.generatedcode.GeneratedRegionTracker;
 import edu.ucr.cs.riple.core.metadata.trackers.generatedcode.LombokTracker;
 import edu.ucr.cs.riple.injector.location.Location;
@@ -48,20 +48,18 @@ public class CompoundTracker implements RegionTracker {
   public CompoundTracker(
       Config config,
       ModuleInfo info,
-      MethodDeclarationTree methodDeclarationTree,
+      MethodRegistry methodRegistry,
       FieldDeclarationStore fieldDeclarationStore) {
-    MethodRegionTracker methodRegionTracker =
-        new MethodRegionTracker(config, info, methodDeclarationTree);
+    MethodRegionTracker methodRegionTracker = new MethodRegionTracker(config, info, methodRegistry);
     this.trackers =
         ImmutableSet.of(
-            new FieldRegionTracker(config, info, fieldDeclarationStore, methodDeclarationTree),
+            new FieldRegionTracker(config, info, fieldDeclarationStore, methodRegistry),
             methodRegionTracker,
-            new ParameterRegionTracker(methodDeclarationTree, methodRegionTracker));
+            new ParameterRegionTracker(methodRegistry, methodRegionTracker));
     ImmutableSet.Builder<GeneratedRegionTracker> generatedRegionTrackerBuilder =
         new ImmutableSet.Builder<>();
     if (config.generatedCodeDetectors.contains(SourceType.LOMBOK)) {
-      generatedRegionTrackerBuilder.add(
-          new LombokTracker(methodDeclarationTree, methodRegionTracker));
+      generatedRegionTrackerBuilder.add(new LombokTracker(methodRegistry, methodRegionTracker));
     }
     this.generatedRegionsTrackers = generatedRegionTrackerBuilder.build();
   }

--- a/annotator-core/src/main/java/edu/ucr/cs/riple/core/metadata/trackers/FieldRegionTracker.java
+++ b/annotator-core/src/main/java/edu/ucr/cs/riple/core/metadata/trackers/FieldRegionTracker.java
@@ -44,7 +44,7 @@ public class FieldRegionTracker extends MetaData<TrackerNode> implements RegionT
    * declaration.
    */
   private final FieldDeclarationStore fieldDeclarationStore;
-  /** The method declaration tree. Used to retrieve constructors for a class */
+  /** The method registry. Used to retrieve constructors for a class */
   private final MethodRegistry methodRegistry;
 
   public FieldRegionTracker(

--- a/annotator-core/src/main/java/edu/ucr/cs/riple/core/metadata/trackers/FieldRegionTracker.java
+++ b/annotator-core/src/main/java/edu/ucr/cs/riple/core/metadata/trackers/FieldRegionTracker.java
@@ -28,7 +28,7 @@ import edu.ucr.cs.riple.core.Config;
 import edu.ucr.cs.riple.core.ModuleInfo;
 import edu.ucr.cs.riple.core.metadata.MetaData;
 import edu.ucr.cs.riple.core.metadata.field.FieldDeclarationStore;
-import edu.ucr.cs.riple.core.metadata.method.MethodDeclarationTree;
+import edu.ucr.cs.riple.core.metadata.method.MethodRegistry;
 import edu.ucr.cs.riple.injector.location.Location;
 import edu.ucr.cs.riple.injector.location.OnField;
 import edu.ucr.cs.riple.scanner.Serializer;
@@ -45,16 +45,16 @@ public class FieldRegionTracker extends MetaData<TrackerNode> implements RegionT
    */
   private final FieldDeclarationStore fieldDeclarationStore;
   /** The method declaration tree. Used to retrieve constructors for a class */
-  private final MethodDeclarationTree methodDeclarationTree;
+  private final MethodRegistry methodRegistry;
 
   public FieldRegionTracker(
       Config config,
       ModuleInfo info,
       FieldDeclarationStore fieldDeclarationStore,
-      MethodDeclarationTree methodDeclarationTree) {
+      MethodRegistry methodRegistry) {
     super(config, info.dir.resolve(Serializer.FIELD_GRAPH_FILE_NAME));
     this.fieldDeclarationStore = fieldDeclarationStore;
-    this.methodDeclarationTree = methodDeclarationTree;
+    this.methodRegistry = methodRegistry;
   }
 
   @Override
@@ -82,7 +82,7 @@ public class FieldRegionTracker extends MetaData<TrackerNode> implements RegionT
     if (fieldDeclarationStore.isUninitializedField(field)) {
       // If not, add all constructors for the class.
       ans.addAll(
-          methodDeclarationTree.getConstructorsForClass(field.clazz).stream()
+          methodRegistry.getConstructorsForClass(field.clazz).stream()
               .map(onMethod -> new Region(onMethod.clazz, onMethod.method))
               .collect(Collectors.toSet()));
     }

--- a/annotator-core/src/main/java/edu/ucr/cs/riple/core/metadata/trackers/ParameterRegionTracker.java
+++ b/annotator-core/src/main/java/edu/ucr/cs/riple/core/metadata/trackers/ParameterRegionTracker.java
@@ -24,7 +24,7 @@
 
 package edu.ucr.cs.riple.core.metadata.trackers;
 
-import edu.ucr.cs.riple.core.metadata.method.MethodDeclarationTree;
+import edu.ucr.cs.riple.core.metadata.method.MethodRegistry;
 import edu.ucr.cs.riple.injector.location.Location;
 import edu.ucr.cs.riple.injector.location.OnParameter;
 import java.util.Optional;
@@ -35,17 +35,17 @@ import java.util.stream.Collectors;
 public class ParameterRegionTracker implements RegionTracker {
 
   /**
-   * {@link MethodDeclarationTree} instance, used to retrieve regions that will be affected due to
+   * {@link MethodRegistry} instance, used to retrieve regions that will be affected due to
    * inheritance violations.
    */
-  private final MethodDeclarationTree methodDeclarationTree;
+  private final MethodRegistry methodRegistry;
 
   /** {@link MethodRegionTracker} instance, used to retrieve all sites. */
   private final MethodRegionTracker methodRegionTracker;
 
   public ParameterRegionTracker(
-      MethodDeclarationTree methodDeclarationTree, MethodRegionTracker methodRegionTracker) {
-    this.methodDeclarationTree = methodDeclarationTree;
+      MethodRegistry methodRegistry, MethodRegionTracker methodRegionTracker) {
+    this.methodRegistry = methodRegistry;
     this.methodRegionTracker = methodRegionTracker;
   }
 
@@ -57,7 +57,7 @@ public class ParameterRegionTracker implements RegionTracker {
     OnParameter parameter = location.toParameter();
     // Get regions which will be potentially affected by inheritance violations.
     Set<Region> regions =
-        methodDeclarationTree.getSubMethods(parameter.method, parameter.clazz, false).stream()
+        methodRegistry.getSubMethods(parameter.method, parameter.clazz, false).stream()
             .map(node -> new Region(node.location.clazz, node.location.method))
             .collect(Collectors.toSet());
     // Add the method the fix is targeting.

--- a/annotator-core/src/main/java/edu/ucr/cs/riple/core/metadata/trackers/generatedcode/LombokTracker.java
+++ b/annotator-core/src/main/java/edu/ucr/cs/riple/core/metadata/trackers/generatedcode/LombokTracker.java
@@ -47,7 +47,7 @@ public class LombokTracker implements GeneratedRegionTracker {
 
   /** Method region tracker to get potentially impacted regions of a method. */
   private final MethodRegionTracker tracker;
-  /** Method declaration tree instance. */
+  /** Method registry instance. */
   private final MethodRegistry methodRegistry;
 
   public LombokTracker(MethodRegistry methodRegistry, MethodRegionTracker methodRegionTracker) {

--- a/annotator-core/src/main/java/edu/ucr/cs/riple/core/metadata/trackers/generatedcode/LombokTracker.java
+++ b/annotator-core/src/main/java/edu/ucr/cs/riple/core/metadata/trackers/generatedcode/LombokTracker.java
@@ -24,7 +24,7 @@
 
 package edu.ucr.cs.riple.core.metadata.trackers.generatedcode;
 
-import edu.ucr.cs.riple.core.metadata.method.MethodDeclarationTree;
+import edu.ucr.cs.riple.core.metadata.method.MethodRegistry;
 import edu.ucr.cs.riple.core.metadata.trackers.MethodRegionTracker;
 import edu.ucr.cs.riple.core.metadata.trackers.Region;
 import edu.ucr.cs.riple.scanner.generatedcode.SourceType;
@@ -48,11 +48,10 @@ public class LombokTracker implements GeneratedRegionTracker {
   /** Method region tracker to get potentially impacted regions of a method. */
   private final MethodRegionTracker tracker;
   /** Method declaration tree instance. */
-  private final MethodDeclarationTree methodDeclarationTree;
+  private final MethodRegistry methodRegistry;
 
-  public LombokTracker(
-      MethodDeclarationTree methodDeclarationTree, MethodRegionTracker methodRegionTracker) {
-    this.methodDeclarationTree = methodDeclarationTree;
+  public LombokTracker(MethodRegistry methodRegistry, MethodRegionTracker methodRegionTracker) {
+    this.methodRegistry = methodRegistry;
     this.tracker = methodRegionTracker;
   }
 
@@ -62,7 +61,7 @@ public class LombokTracker implements GeneratedRegionTracker {
         // filter regions which are created by lombok
         .filter(region -> region.sourceType.equals(SourceType.LOMBOK) && region.isOnMethod())
         // find the corresponding method for the region.
-        .map(region -> methodDeclarationTree.findNode(region.member, region.clazz))
+        .map(region -> methodRegistry.findNode(region.member, region.clazz))
         .filter(Objects::nonNull)
         // get method location.
         .map(methodNode -> methodNode.location)


### PR DESCRIPTION
`MethodDeclarationTree` contains all the records deserialized from `AnnotatorScanner` which stores declaration information for each method. This PR renames `MethodDeclarationTree` to `MethodRegistry` and `MethodNode` to `MethodRecord` to better reflect the class purpose.