### PR TITLE
Mock only buildTarget static method

### DIFF
--- a/annotator-core/src/main/java/edu/ucr/cs/riple/core/metadata/index/Index.java
+++ b/annotator-core/src/main/java/edu/ucr/cs/riple/core/metadata/index/Index.java
@@ -24,14 +24,13 @@
 
 package edu.ucr.cs.riple.core.metadata.index;
 
-import static java.nio.charset.StandardCharsets.UTF_8;
-
 import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Multimap;
 import com.google.common.collect.MultimapBuilder;
 import edu.ucr.cs.riple.core.metadata.trackers.Region;
 import java.io.BufferedReader;
 import java.io.IOException;
+import java.nio.charset.Charset;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.Collection;
@@ -70,7 +69,7 @@ public class Index {
     items.clear();
     paths.forEach(
         path -> {
-          try (BufferedReader br = Files.newBufferedReader(path, UTF_8)) {
+          try (BufferedReader br = Files.newBufferedReader(path, Charset.defaultCharset())) {
             String line = br.readLine();
             // Skip TSV header.
             if (line != null) {

--- a/annotator-core/src/main/java/edu/ucr/cs/riple/core/util/Utility.java
+++ b/annotator-core/src/main/java/edu/ucr/cs/riple/core/util/Utility.java
@@ -362,7 +362,7 @@ public class Utility {
    * @return The lines from the file as a Stream.
    */
   public static List<String> readFileLines(Path path) {
-    try (Stream<String> stream = Files.lines(path)) {
+    try (Stream<String> stream = Files.lines(path, Charset.defaultCharset())) {
       return stream.collect(Collectors.toList());
     } catch (IOException e) {
       throw new RuntimeException("Exception while reading file: " + path, e);

--- a/annotator-core/src/test/java/edu/ucr/cs/riple/core/tools/Utility.java
+++ b/annotator-core/src/test/java/edu/ucr/cs/riple/core/tools/Utility.java
@@ -145,7 +145,7 @@ public class Utility {
    */
   public static void runTestWithMockedBuild(Path testDir, Runnable runnable) {
     try (MockedStatic<edu.ucr.cs.riple.core.util.Utility> utilMock =
-        Mockito.mockStatic(edu.ucr.cs.riple.core.util.Utility.class)) {
+        Mockito.mockStatic(edu.ucr.cs.riple.core.util.Utility.class, Mockito.CALLS_REAL_METHODS)) {
       utilMock
           .when(() -> edu.ucr.cs.riple.core.util.Utility.buildTarget(Mockito.any()))
           .thenAnswer(


### PR DESCRIPTION
This PR is a follow up for #178 to only mock `buildTarget` static method and call the actual method for other static methods. This will enable us to reuse the methods in the mocked `Utility` class without requiring writing a mock for each method.