### PR TITLE
Add missing equals and hashcode to Change subclasses

### DIFF
--- a/injector/src/main/java/edu/ucr/cs/riple/injector/changes/AddMarkerAnnotation.java
+++ b/injector/src/main/java/edu/ucr/cs/riple/injector/changes/AddMarkerAnnotation.java
@@ -31,6 +31,7 @@ import com.github.javaparser.ast.nodeTypes.NodeWithRange;
 import edu.ucr.cs.riple.injector.location.Location;
 import edu.ucr.cs.riple.injector.modifications.Insertion;
 import edu.ucr.cs.riple.injector.modifications.Modification;
+import java.util.Objects;
 import javax.annotation.Nullable;
 
 /**
@@ -67,5 +68,22 @@ public class AddMarkerAnnotation extends AnnotationChange implements AddAnnotati
   @Override
   public RemoveAnnotation getReverse() {
     return new RemoveMarkerAnnotation(location, annotationName.fullName);
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (!(o instanceof AddMarkerAnnotation)) {
+      return false;
+    }
+    AddMarkerAnnotation that = (AddMarkerAnnotation) o;
+    return location.equals(that.location) && annotationName.equals(that.annotationName);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash("ADD", location, annotationName);
   }
 }

--- a/injector/src/main/java/edu/ucr/cs/riple/injector/changes/AddSingleElementAnnotation.java
+++ b/injector/src/main/java/edu/ucr/cs/riple/injector/changes/AddSingleElementAnnotation.java
@@ -36,6 +36,7 @@ import edu.ucr.cs.riple.injector.location.Location;
 import edu.ucr.cs.riple.injector.modifications.Insertion;
 import edu.ucr.cs.riple.injector.modifications.Modification;
 import edu.ucr.cs.riple.injector.modifications.Replacement;
+import java.util.Objects;
 import java.util.Optional;
 import javax.annotation.Nullable;
 
@@ -162,5 +163,23 @@ public class AddSingleElementAnnotation extends AnnotationChange implements AddA
   public RemoveAnnotation getReverse() {
     throw new UnsupportedOperationException(
         "Annotation deletion for single element annotations is not supported yet.");
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (!(o instanceof AddSingleElementAnnotation)) {
+      return false;
+    }
+    if (!super.equals(o)) return false;
+    AddSingleElementAnnotation that = (AddSingleElementAnnotation) o;
+    return repeatable == that.repeatable && Objects.equals(argument, that.argument);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(super.hashCode(), argument, repeatable);
   }
 }

--- a/injector/src/main/java/edu/ucr/cs/riple/injector/changes/AddSingleElementAnnotation.java
+++ b/injector/src/main/java/edu/ucr/cs/riple/injector/changes/AddSingleElementAnnotation.java
@@ -173,7 +173,9 @@ public class AddSingleElementAnnotation extends AnnotationChange implements AddA
     if (!(o instanceof AddSingleElementAnnotation)) {
       return false;
     }
-    if (!super.equals(o)) return false;
+    if (!super.equals(o)) {
+      return false;
+    }
     AddSingleElementAnnotation that = (AddSingleElementAnnotation) o;
     return repeatable == that.repeatable && Objects.equals(argument, that.argument);
   }

--- a/injector/src/main/java/edu/ucr/cs/riple/injector/changes/RemoveMarkerAnnotation.java
+++ b/injector/src/main/java/edu/ucr/cs/riple/injector/changes/RemoveMarkerAnnotation.java
@@ -30,6 +30,7 @@ import com.github.javaparser.ast.nodeTypes.NodeWithRange;
 import edu.ucr.cs.riple.injector.location.Location;
 import edu.ucr.cs.riple.injector.modifications.Deletion;
 import edu.ucr.cs.riple.injector.modifications.Modification;
+import java.util.Objects;
 import java.util.Optional;
 import javax.annotation.Nullable;
 
@@ -61,5 +62,23 @@ public class RemoveMarkerAnnotation extends AnnotationChange implements RemoveAn
       }
     }
     return null;
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (!(o instanceof RemoveMarkerAnnotation)) {
+      return false;
+    }
+    RemoveMarkerAnnotation other = (RemoveMarkerAnnotation) o;
+    return Objects.equals(location, other.location)
+        && Objects.equals(annotationName, other.annotationName);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash("REMOVE-MARKER", location, annotationName);
   }
 }


### PR DESCRIPTION
This PR adds the missing `equals` and `hashcode` definitions in #186.