### PR TITLE
Refactor MetaData class

### DIFF
--- a/annotator-core/src/main/java/edu/ucr/cs/riple/core/metadata/Registry.java
+++ b/annotator-core/src/main/java/edu/ucr/cs/riple/core/metadata/Registry.java
@@ -26,7 +26,6 @@ package edu.ucr.cs.riple.core.metadata;
 
 import com.google.common.collect.ImmutableMultimap;
 import com.google.common.collect.ImmutableSet;
-import com.google.common.collect.Multimap;
 import edu.ucr.cs.riple.core.Config;
 import java.io.BufferedReader;
 import java.io.IOException;
@@ -42,15 +41,18 @@ import java.util.stream.Stream;
  * hash of the item and the value is the item itself. For faster retrieval, if the anticipated hash
  * is known, {@link Registry#findNodesWithHashHint} can be used, otherwise use {@link
  * Registry#findNodes}. If subclasses need to initialize some data before loading the file, they
- * must call {@link Registry#setup()}.
+ * must call {@link Registry#setup()}. Please note that this class anticipates that the file exits
+ * at the given paths and does not attempt to create it. Before creating an instance, please make
+ * sure that the file exists.
  */
 public abstract class Registry<T> {
 
   /**
    * Contents, every element is mapped to it's computed hash, note that two different items can have
-   * an identical hash, therefore it is of type {@link Multimap} (not HashMap) to hold both items.
+   * an identical hash, therefore it is of type {@link ImmutableMultimap} ({@link
+   * java.util.HashMap}) to hold both items.
    */
-  protected final Multimap<Integer, T> contents;
+  protected final ImmutableMultimap<Integer, T> contents;
   /** Annotator config. */
   protected final Config config;
 
@@ -96,13 +98,13 @@ public abstract class Registry<T> {
   }
 
   /**
-   * Subclasses can override this method to perform eny initialization before loading data from the
+   * Subclasses can override this method to perform any initialization before loading data from the
    * file.
    */
   protected void setup() {}
 
   /**
-   * Loads data to contents.
+   * Loads data existing in the given path, to the given builder.
    *
    * @param path Path to the file containing data.
    * @throws IOException if file not is found.

--- a/annotator-core/src/main/java/edu/ucr/cs/riple/core/metadata/Registry.java
+++ b/annotator-core/src/main/java/edu/ucr/cs/riple/core/metadata/Registry.java
@@ -116,6 +116,7 @@ public abstract class Registry<T> {
       Builder<T> recordBuilder = getBuilder();
       String line = reader.readLine();
       if (line != null) {
+        // Skip header
         line = reader.readLine();
       }
       while (line != null) {
@@ -160,8 +161,9 @@ public abstract class Registry<T> {
   }
 
   /**
-   * Retrieves stream of nodes which holds the passed predicate. This method does not hash and is
-   * significantly slower than {@link Registry#findNodesWithHashHint(Predicate, int)};
+   * Retrieves stream of nodes which holds the passed predicate. This method is expected to be
+   * significantly slower than {@link Registry#findNodesWithHashHint}, if the anticipated hash is
+   * known, please use {@link Registry#findNodesWithHashHint}.
    *
    * @param c Predicate.
    * @return Corresponding stream of {@code T}.

--- a/annotator-core/src/main/java/edu/ucr/cs/riple/core/metadata/Registry.java
+++ b/annotator-core/src/main/java/edu/ucr/cs/riple/core/metadata/Registry.java
@@ -34,6 +34,7 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.function.Predicate;
 import java.util.stream.Stream;
+import javax.annotation.Nullable;
 
 /**
  * Container class which loads its content from a file in TSV format. For faster retrieval, it
@@ -144,6 +145,7 @@ public abstract class Registry<T> {
    * @param hash Expected hash
    * @return Corresponding {@code T}.
    */
+  @Nullable
   protected T findRecordWithHashHint(Predicate<T> c, int hash) {
     return findRecordsWithHashHint(c, hash).findFirst().orElse(null);
   }
@@ -157,6 +159,9 @@ public abstract class Registry<T> {
    * @return Corresponding stream of {@code T}.
    */
   protected Stream<T> findRecordsWithHashHint(Predicate<T> c, int hash) {
+    if (!contents.containsKey(hash)) {
+      return Stream.of();
+    }
     return contents.get(hash).stream().filter(c);
   }
 

--- a/annotator-core/src/main/java/edu/ucr/cs/riple/core/metadata/Registry.java
+++ b/annotator-core/src/main/java/edu/ucr/cs/riple/core/metadata/Registry.java
@@ -39,8 +39,8 @@ import java.util.stream.Stream;
  * Container class which loads its content from a file in TSV format. For faster retrieval, it
  * stores its content in a {@link com.google.common.collect.ImmutableMultimap} where the key is the
  * hash of the item and the value is the item itself. For faster retrieval, if the anticipated hash
- * is known, {@link Registry#findNodesWithHashHint} can be used, otherwise use {@link
- * Registry#findNodes}. If subclasses need to initialize some data before loading the file, they
+ * is known, {@link Registry#findRecordsWithHashHint} can be used, otherwise use {@link
+ * Registry#findRecords}. If subclasses need to initialize some data before loading the file, they
  * must call {@link Registry#setup()}. Please note that this class anticipates that the file exits
  * at the given paths and does not attempt to create it. Before creating an instance, please make
  * sure that the file exists.
@@ -120,9 +120,9 @@ public abstract class Registry<T> {
         line = reader.readLine();
       }
       while (line != null) {
-        T node = recordBuilder.build(line.split("\t"));
-        if (node != null) {
-          builder.put(node.hashCode(), node);
+        T record = recordBuilder.build(line.split("\t"));
+        if (record != null) {
+          builder.put(record.hashCode(), record);
         }
         line = reader.readLine();
       }
@@ -138,37 +138,37 @@ public abstract class Registry<T> {
   protected abstract Builder<T> getBuilder();
 
   /**
-   * Retrieves node which holds the passed predicate. It uses the given hash for faster retrieval.
+   * Retrieves record which holds the passed predicate. It uses the given hash for faster retrieval.
    *
    * @param c Predicate.
    * @param hash Expected hash
    * @return Corresponding {@code T}.
    */
-  protected T findNodeWithHashHint(Predicate<T> c, int hash) {
-    return findNodesWithHashHint(c, hash).findFirst().orElse(null);
+  protected T findRecordWithHashHint(Predicate<T> c, int hash) {
+    return findRecordsWithHashHint(c, hash).findFirst().orElse(null);
   }
 
   /**
-   * Retrieves stream of nodes which holds the passed predicate. It uses the given hash for faster
+   * Retrieves stream of records which holds the passed predicate. It uses the given hash for faster
    * retrieval.
    *
    * @param c Predicate.
    * @param hash Expected hash
    * @return Corresponding stream of {@code T}.
    */
-  protected Stream<T> findNodesWithHashHint(Predicate<T> c, int hash) {
+  protected Stream<T> findRecordsWithHashHint(Predicate<T> c, int hash) {
     return contents.get(hash).stream().filter(c);
   }
 
   /**
-   * Retrieves stream of nodes which holds the passed predicate. This method is expected to be
-   * significantly slower than {@link Registry#findNodesWithHashHint}, if the anticipated hash is
-   * known, please use {@link Registry#findNodesWithHashHint}.
+   * Retrieves stream of records which holds the passed predicate. This method is expected to be
+   * significantly slower than {@link Registry#findRecordsWithHashHint}, if the anticipated hash is
+   * known, please use {@link Registry#findRecordsWithHashHint}.
    *
    * @param c Predicate.
    * @return Corresponding stream of {@code T}.
    */
-  protected Stream<T> findNodes(Predicate<T> c) {
+  protected Stream<T> findRecords(Predicate<T> c) {
     return contents.values().stream().filter(c);
   }
 

--- a/annotator-core/src/main/java/edu/ucr/cs/riple/core/metadata/field/FieldInitializationStore.java
+++ b/annotator-core/src/main/java/edu/ucr/cs/riple/core/metadata/field/FieldInitializationStore.java
@@ -59,7 +59,7 @@ public class FieldInitializationStore extends Registry<FieldInitializationNode> 
     Map<String, Class> classes = new HashMap<>();
     uninitializedFields.forEach(
         onField ->
-            findNodesWithHashHint(
+            findRecordsWithHashHint(
                     candidate ->
                         onField.isOnFieldWithName(candidate.getFieldName())
                             && candidate.getClassName().equals(onField.clazz),

--- a/annotator-core/src/main/java/edu/ucr/cs/riple/core/metadata/field/FieldInitializationStore.java
+++ b/annotator-core/src/main/java/edu/ucr/cs/riple/core/metadata/field/FieldInitializationStore.java
@@ -2,7 +2,7 @@ package edu.ucr.cs.riple.core.metadata.field;
 
 import com.google.common.base.Preconditions;
 import edu.ucr.cs.riple.core.Config;
-import edu.ucr.cs.riple.core.metadata.MetaData;
+import edu.ucr.cs.riple.core.metadata.Registry;
 import edu.ucr.cs.riple.injector.location.Location;
 import edu.ucr.cs.riple.injector.location.OnField;
 import edu.ucr.cs.riple.injector.location.OnMethod;
@@ -19,7 +19,7 @@ import java.util.stream.Collectors;
  * Detects initializer methods in source code. Reads field initialization info serialized by
  * NullAway and uses a heuristic to detect them.
  */
-public class FieldInitializationStore extends MetaData<FieldInitializationNode> {
+public class FieldInitializationStore extends Registry<FieldInitializationNode> {
 
   /**
    * Output file name. It contains information about initializations of fields via methods. On each

--- a/annotator-core/src/main/java/edu/ucr/cs/riple/core/metadata/field/FieldInitializationStore.java
+++ b/annotator-core/src/main/java/edu/ucr/cs/riple/core/metadata/field/FieldInitializationStore.java
@@ -39,16 +39,6 @@ public class FieldInitializationStore extends Registry<FieldInitializationNode> 
     super(config, config.target.dir.resolve(FILE_NAME));
   }
 
-  @Override
-  protected FieldInitializationNode addNodeByLine(String[] values) {
-    Location location = Location.createLocationFromArrayInfo(values);
-    Preconditions.checkNotNull(
-        location, "Field Location cannot be null: " + Arrays.toString(values));
-    return location.isOnMethod()
-        ? new FieldInitializationNode(location.toMethod(), values[6])
-        : null;
-  }
-
   /**
    * Processes all uninitialized fields and method initializers and chooses the initializers with
    * the heuristic below:
@@ -84,6 +74,18 @@ public class FieldInitializationStore extends Registry<FieldInitializationNode> 
         .map(Class::findInitializer)
         .filter(Objects::nonNull)
         .collect(Collectors.toSet());
+  }
+
+  @Override
+  protected Builder<FieldInitializationNode> getBuilder() {
+    return values -> {
+      Location location = Location.createLocationFromArrayInfo(values);
+      Preconditions.checkNotNull(
+          location, "Field Location cannot be null: " + Arrays.toString(values));
+      return location.isOnMethod()
+          ? new FieldInitializationNode(location.toMethod(), values[6])
+          : null;
+    };
   }
 
   /** Stores class field / method initialization status. */

--- a/annotator-core/src/main/java/edu/ucr/cs/riple/core/metadata/field/FieldRegistry.java
+++ b/annotator-core/src/main/java/edu/ucr/cs/riple/core/metadata/field/FieldRegistry.java
@@ -131,7 +131,7 @@ public class FieldRegistry extends Registry<FieldRecord> {
   public ImmutableSet<String> getInLineMultipleFieldDeclarationsOnField(
       String clazz, Set<String> fields) {
     FieldRecord candidate =
-        findNodeWithHashHint(node -> node.clazz.equals(clazz), FieldRecord.hash(clazz));
+        findRecordWithHashHint(node -> node.clazz.equals(clazz), FieldRecord.hash(clazz));
     if (candidate == null) {
       // No inline multiple field declarations.
       return ImmutableSet.copyOf(fields);
@@ -164,7 +164,7 @@ public class FieldRegistry extends Registry<FieldRecord> {
    */
   public OnField getLocationOnField(String clazz, String field) {
     FieldRecord candidate =
-        findNodeWithHashHint(node -> node.clazz.equals(clazz), FieldRecord.hash(clazz));
+        findRecordWithHashHint(node -> node.clazz.equals(clazz), FieldRecord.hash(clazz));
     Set<String> fieldNames = Sets.newHashSet(field);
     if (candidate == null) {
       // field is on byte code.
@@ -183,7 +183,7 @@ public class FieldRegistry extends Registry<FieldRecord> {
    */
   public OnClass getLocationOnClass(String clazz) {
     FieldRecord candidate =
-        findNodeWithHashHint(node -> node.clazz.equals(clazz), FieldRecord.hash(clazz));
+        findRecordWithHashHint(node -> node.clazz.equals(clazz), FieldRecord.hash(clazz));
     if (candidate == null) {
       // class not observed in source code.
       return null;

--- a/annotator-core/src/main/java/edu/ucr/cs/riple/core/metadata/field/FieldRegistry.java
+++ b/annotator-core/src/main/java/edu/ucr/cs/riple/core/metadata/field/FieldRegistry.java
@@ -12,7 +12,7 @@ import com.google.common.collect.MultimapBuilder;
 import com.google.common.collect.Sets;
 import edu.ucr.cs.riple.core.Config;
 import edu.ucr.cs.riple.core.ModuleInfo;
-import edu.ucr.cs.riple.core.metadata.MetaData;
+import edu.ucr.cs.riple.core.metadata.Registry;
 import edu.ucr.cs.riple.injector.Helper;
 import edu.ucr.cs.riple.injector.exceptions.TargetClassNotFound;
 import edu.ucr.cs.riple.injector.location.OnClass;
@@ -33,7 +33,7 @@ import java.util.Set;
  * j; and a Fix suggesting f to be {@code Nullable}, this class will replace that fix with a fix
  * suggesting f, i, and j be {@code Nullable}.)
  */
-public class FieldRegistry extends MetaData<FieldRecord> {
+public class FieldRegistry extends Registry<FieldRecord> {
 
   /**
    * A map from class flat name to a set of field names that are declared in that class but not

--- a/annotator-core/src/main/java/edu/ucr/cs/riple/core/metadata/index/NonnullStore.java
+++ b/annotator-core/src/main/java/edu/ucr/cs/riple/core/metadata/index/NonnullStore.java
@@ -25,7 +25,7 @@
 package edu.ucr.cs.riple.core.metadata.index;
 
 import edu.ucr.cs.riple.core.Config;
-import edu.ucr.cs.riple.core.metadata.MetaData;
+import edu.ucr.cs.riple.core.metadata.Registry;
 import edu.ucr.cs.riple.injector.location.Location;
 import edu.ucr.cs.riple.scanner.Serializer;
 
@@ -34,7 +34,7 @@ import edu.ucr.cs.riple.scanner.Serializer;
  * acknowledge these annotations and prevent annotator from annotating such elements with
  * {@code @Nullable} annotations.
  */
-public class NonnullStore extends MetaData<Location> {
+public class NonnullStore extends Registry<Location> {
 
   public NonnullStore(Config config) {
     super(config, config.target.dir.resolve(Serializer.NON_NULL_ELEMENTS_FILE_NAME));

--- a/annotator-core/src/main/java/edu/ucr/cs/riple/core/metadata/index/NonnullStore.java
+++ b/annotator-core/src/main/java/edu/ucr/cs/riple/core/metadata/index/NonnullStore.java
@@ -41,8 +41,8 @@ public class NonnullStore extends Registry<Location> {
   }
 
   @Override
-  protected Location addNodeByLine(String[] values) {
-    return Location.createLocationFromArrayInfo(values);
+  protected Builder<Location> getBuilder() {
+    return Location::createLocationFromArrayInfo;
   }
 
   /**

--- a/annotator-core/src/main/java/edu/ucr/cs/riple/core/metadata/index/NonnullStore.java
+++ b/annotator-core/src/main/java/edu/ucr/cs/riple/core/metadata/index/NonnullStore.java
@@ -48,10 +48,10 @@ public class NonnullStore extends Registry<Location> {
   /**
    * Returns true if the element at the given location has an explicit {@code @Nonnull} annotation.
    *
-   * @param location Location of the given element.
+   * @param target Location of the given element.
    * @return true, if the element at the given location has an explicit {@code @Nonnull} annotation.
    */
-  public boolean hasExplicitNonnullAnnotation(Location location) {
-    return contents.values().stream().anyMatch(l -> l.equals(location));
+  public boolean hasExplicitNonnullAnnotation(Location target) {
+    return findRecordWithHashHint(location -> location.equals(target), target.hashCode()) != null;
   }
 }

--- a/annotator-core/src/main/java/edu/ucr/cs/riple/core/metadata/method/MethodRegistry.java
+++ b/annotator-core/src/main/java/edu/ucr/cs/riple/core/metadata/method/MethodRegistry.java
@@ -155,7 +155,7 @@ public class MethodRegistry extends Registry<MethodRecord> {
    * @return Corresponding method.
    */
   public MethodRecord findMethodByName(String encClass, String method) {
-    return findNodeWithHashHint(
+    return findRecordWithHashHint(
         candidate ->
             candidate.location.clazz.equals(encClass) && candidate.location.method.equals(method),
         MethodRecord.hash(method, encClass));
@@ -167,7 +167,7 @@ public class MethodRegistry extends Registry<MethodRecord> {
    * @return ImmutableSet of method nodes.
    */
   public ImmutableSet<MethodRecord> getPublicMethodsWithNonPrimitivesReturn() {
-    return findNodes(MethodRecord::isPublicMethodWithNonPrimitiveReturnType)
+    return findRecords(MethodRecord::isPublicMethodWithNonPrimitiveReturnType)
         .collect(ImmutableSet.toImmutableSet());
   }
 

--- a/annotator-core/src/main/java/edu/ucr/cs/riple/core/metadata/method/MethodRegistry.java
+++ b/annotator-core/src/main/java/edu/ucr/cs/riple/core/metadata/method/MethodRegistry.java
@@ -28,7 +28,7 @@ import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Multimap;
 import com.google.common.collect.MultimapBuilder;
 import edu.ucr.cs.riple.core.Config;
-import edu.ucr.cs.riple.core.metadata.MetaData;
+import edu.ucr.cs.riple.core.metadata.Registry;
 import edu.ucr.cs.riple.injector.Helper;
 import edu.ucr.cs.riple.injector.location.Location;
 import edu.ucr.cs.riple.injector.location.OnMethod;
@@ -43,7 +43,7 @@ import javax.annotation.Nullable;
  * The top-down tree structure of methods in the target module, where each method's parent node, is
  * their immediate overriding method.
  */
-public class MethodRegistry extends MetaData<MethodRecord> {
+public class MethodRegistry extends Registry<MethodRecord> {
 
   /** Each method has a unique id across all methods. This hashmap, maps ids to nodes. */
   private HashMap<Integer, MethodRecord> nodes;

--- a/annotator-core/src/main/java/edu/ucr/cs/riple/core/metadata/method/MethodRegistry.java
+++ b/annotator-core/src/main/java/edu/ucr/cs/riple/core/metadata/method/MethodRegistry.java
@@ -67,46 +67,48 @@ public class MethodRegistry extends Registry<MethodRecord> {
   }
 
   @Override
-  protected MethodRecord addNodeByLine(String[] values) {
-    // Nodes unique id.
-    Integer id = Integer.parseInt(values[0]);
-    MethodRecord node;
-    if (nodes.containsKey(id)) {
-      node = nodes.get(id);
-    } else {
-      node = new MethodRecord(id);
-      nodes.put(id, node);
-    }
-    // Fill nodes information.
-    Integer parentId = Integer.parseInt(values[3]);
-    OnMethod location = new OnMethod(Helper.deserializePath(values[8]), values[1], values[2]);
-    boolean isConstructor =
-        Helper.extractCallableName(location.method).equals(Helper.simpleName(location.clazz));
-    node.fillInformation(
-        new OnMethod(Helper.deserializePath(values[8]), values[1], values[2]),
-        parentId,
-        Boolean.parseBoolean(values[5]),
-        values[6],
-        Boolean.parseBoolean(values[7]),
-        isConstructor);
-    // If node has a non-top parent.
-    if (parentId > 0) {
-      MethodRecord parent = nodes.get(parentId);
-      // If parent has not been seen visited before.
-      if (parent == null) {
-        parent = new MethodRecord(parentId);
-        nodes.put(parentId, parent);
+  protected Builder<MethodRecord> getBuilder() {
+    return values -> {
+      // Nodes unique id.
+      Integer id = Integer.parseInt(values[0]);
+      MethodRecord node;
+      if (nodes.containsKey(id)) {
+        node = nodes.get(id);
+      } else {
+        node = new MethodRecord(id);
+        nodes.put(id, node);
       }
-      // Parent is already visited.
-      parent.addChild(id);
-    }
-    // Update list of all declared classes.
-    declaredClasses.add(node.location.clazz);
-    // If node is a constructor, add it to the list of constructors of its class.
-    if (node.isConstructor) {
-      classConstructorMap.put(node.location.clazz, node);
-    }
-    return node;
+      // Fill nodes information.
+      Integer parentId = Integer.parseInt(values[3]);
+      OnMethod location = new OnMethod(Helper.deserializePath(values[8]), values[1], values[2]);
+      boolean isConstructor =
+          Helper.extractCallableName(location.method).equals(Helper.simpleName(location.clazz));
+      node.fillInformation(
+          new OnMethod(Helper.deserializePath(values[8]), values[1], values[2]),
+          parentId,
+          Boolean.parseBoolean(values[5]),
+          values[6],
+          Boolean.parseBoolean(values[7]),
+          isConstructor);
+      // If node has a non-top parent.
+      if (parentId > 0) {
+        MethodRecord parent = nodes.get(parentId);
+        // If parent has not been seen visited before.
+        if (parent == null) {
+          parent = new MethodRecord(parentId);
+          nodes.put(parentId, parent);
+        }
+        // Parent is already visited.
+        parent.addChild(id);
+      }
+      // Update list of all declared classes.
+      declaredClasses.add(node.location.clazz);
+      // If node is a constructor, add it to the list of constructors of its class.
+      if (node.isConstructor) {
+        classConstructorMap.put(node.location.clazz, node);
+      }
+      return node;
+    };
   }
 
   /**

--- a/annotator-core/src/main/java/edu/ucr/cs/riple/core/metadata/trackers/FieldRegionTracker.java
+++ b/annotator-core/src/main/java/edu/ucr/cs/riple/core/metadata/trackers/FieldRegionTracker.java
@@ -56,8 +56,8 @@ public class FieldRegionTracker extends Registry<TrackerNode> implements RegionT
   }
 
   @Override
-  protected TrackerNode addNodeByLine(String[] values) {
-    return Utility.deserializeTrackerNode(values);
+  protected Builder<TrackerNode> getBuilder() {
+    return Utility::deserializeTrackerNode;
   }
 
   @Override

--- a/annotator-core/src/main/java/edu/ucr/cs/riple/core/metadata/trackers/FieldRegionTracker.java
+++ b/annotator-core/src/main/java/edu/ucr/cs/riple/core/metadata/trackers/FieldRegionTracker.java
@@ -26,7 +26,7 @@ package edu.ucr.cs.riple.core.metadata.trackers;
 
 import edu.ucr.cs.riple.core.Config;
 import edu.ucr.cs.riple.core.ModuleInfo;
-import edu.ucr.cs.riple.core.metadata.MetaData;
+import edu.ucr.cs.riple.core.metadata.Registry;
 import edu.ucr.cs.riple.core.metadata.field.FieldRegistry;
 import edu.ucr.cs.riple.core.metadata.method.MethodRegistry;
 import edu.ucr.cs.riple.core.util.Utility;
@@ -38,7 +38,7 @@ import java.util.Set;
 import java.util.stream.Collectors;
 
 /** Tracker for Fields. */
-public class FieldRegionTracker extends MetaData<TrackerNode> implements RegionTracker {
+public class FieldRegionTracker extends Registry<TrackerNode> implements RegionTracker {
 
   /**
    * Store for field declarations. This is used to determine if a field is initialized at

--- a/annotator-core/src/main/java/edu/ucr/cs/riple/core/metadata/trackers/FieldRegionTracker.java
+++ b/annotator-core/src/main/java/edu/ucr/cs/riple/core/metadata/trackers/FieldRegionTracker.java
@@ -68,7 +68,7 @@ public class FieldRegionTracker extends Registry<TrackerNode> implements RegionT
     OnField field = location.toField();
     // Add all regions where the field is assigned a new value or read.
     Set<Region> ans =
-        findNodesWithHashHint(
+        findRecordsWithHashHint(
                 candidate ->
                     candidate.calleeClass.equals(field.clazz)
                         && field.isOnFieldWithName(candidate.calleeMember),

--- a/annotator-core/src/main/java/edu/ucr/cs/riple/core/metadata/trackers/MethodRegionTracker.java
+++ b/annotator-core/src/main/java/edu/ucr/cs/riple/core/metadata/trackers/MethodRegionTracker.java
@@ -63,8 +63,8 @@ public class MethodRegionTracker extends Registry<TrackerNode> implements Region
   }
 
   @Override
-  protected TrackerNode addNodeByLine(String[] values) {
-    return Utility.deserializeTrackerNode(values);
+  protected Builder<TrackerNode> getBuilder() {
+    return Utility::deserializeTrackerNode;
   }
 
   @Override

--- a/annotator-core/src/main/java/edu/ucr/cs/riple/core/metadata/trackers/MethodRegionTracker.java
+++ b/annotator-core/src/main/java/edu/ucr/cs/riple/core/metadata/trackers/MethodRegionTracker.java
@@ -27,7 +27,7 @@ package edu.ucr.cs.riple.core.metadata.trackers;
 import com.google.common.collect.ImmutableSet;
 import edu.ucr.cs.riple.core.Config;
 import edu.ucr.cs.riple.core.ModuleInfo;
-import edu.ucr.cs.riple.core.metadata.MetaData;
+import edu.ucr.cs.riple.core.metadata.Registry;
 import edu.ucr.cs.riple.core.metadata.method.MethodRecord;
 import edu.ucr.cs.riple.core.metadata.method.MethodRegistry;
 import edu.ucr.cs.riple.core.util.Utility;
@@ -39,7 +39,7 @@ import java.util.Set;
 import java.util.stream.Collectors;
 
 /** Tracker for Methods. */
-public class MethodRegionTracker extends MetaData<TrackerNode> implements RegionTracker {
+public class MethodRegionTracker extends Registry<TrackerNode> implements RegionTracker {
 
   /**
    * {@link MethodRegistry} instance, used to retrieve regions that will be affected due to

--- a/annotator-core/src/main/java/edu/ucr/cs/riple/core/metadata/trackers/MethodRegionTracker.java
+++ b/annotator-core/src/main/java/edu/ucr/cs/riple/core/metadata/trackers/MethodRegionTracker.java
@@ -93,7 +93,7 @@ public class MethodRegionTracker extends Registry<TrackerNode> implements Region
    * @return Set of regions where target method is called.
    */
   public Set<Region> getCallersOfMethod(String clazz, String method) {
-    return findNodesWithHashHint(
+    return findRecordsWithHashHint(
             candidate ->
                 candidate.calleeClass.equals(clazz) && candidate.calleeMember.equals(method),
             TrackerNode.hash(clazz))


### PR DESCRIPTION
This PR renames `MetaData` to `Registry` along refactoring its implementation. It updates its primary storage to `ImmutableMultiMap` from `MultiMap`.

Previous to this PR, `MetaData` was holding collection of `Nodes`. With new naming scheme, `Registry` is storing collection of `Records`.