### PR TITLE
Rename display subclasses in scanner/test

### DIFF
--- a/annotator-scanner/src/test/java/edu/ucr/cs/riple/scanner/ClassRecordTest.java
+++ b/annotator-scanner/src/test/java/edu/ucr/cs/riple/scanner/ClassRecordTest.java
@@ -25,23 +25,23 @@
 package edu.ucr.cs.riple.scanner;
 
 import com.google.common.base.Preconditions;
-import edu.ucr.cs.riple.scanner.tools.ClassInfoDisplay;
+import edu.ucr.cs.riple.scanner.tools.ClassRecordDisplay;
 import edu.ucr.cs.riple.scanner.tools.DisplayFactory;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
 
 @RunWith(JUnit4.class)
-public class ClassRecordTest extends AnnotatorScannerBaseTest<ClassInfoDisplay> {
+public class ClassRecordTest extends AnnotatorScannerBaseTest<ClassRecordDisplay> {
 
-  private static final DisplayFactory<ClassInfoDisplay> CLASS_DISPLAY_FACTORY =
+  private static final DisplayFactory<ClassRecordDisplay> CLASS_DISPLAY_FACTORY =
       values -> {
         Preconditions.checkArgument(values.length == 2, "Expected to find 2 values on each line");
         // Outputs are written in Temp Directory and is not known at compile time, therefore,
         // relative paths are getting compared.
-        ClassInfoDisplay display = new ClassInfoDisplay(values[0], values[1]);
+        ClassRecordDisplay display = new ClassRecordDisplay(values[0], values[1]);
         display.path = display.path.substring(display.path.indexOf("edu/ucr/"));
-        return new ClassInfoDisplay(values[0], values[1].substring(1));
+        return new ClassRecordDisplay(values[0], values[1].substring(1));
       };
   private static final String HEADER = "class\tpath";
   private static final String FILE_NAME = "class_records.tsv";
@@ -54,7 +54,7 @@ public class ClassRecordTest extends AnnotatorScannerBaseTest<ClassInfoDisplay> 
   public void basicTest() {
     tester
         .addSourceLines("edu/ucr/A.java", "package edu.ucr;", "public class A", "{", "}")
-        .setExpectedOutputs(new ClassInfoDisplay("edu.ucr.A", "edu/ucr/A.java"))
+        .setExpectedOutputs(new ClassRecordDisplay("edu.ucr.A", "edu/ucr/A.java"))
         .doTest();
   }
 
@@ -63,19 +63,19 @@ public class ClassRecordTest extends AnnotatorScannerBaseTest<ClassInfoDisplay> 
     tester
         .addSourceFile("SampleClassForTest.java")
         .setExpectedOutputs(
-            new ClassInfoDisplay(
+            new ClassRecordDisplay(
                 "edu.ucr.cs.riple.scanner.testdata.SampleClassForTest",
                 "edu/ucr/cs/riple/scanner/SampleClassForTest.java"),
-            new ClassInfoDisplay(
+            new ClassRecordDisplay(
                 "edu.ucr.cs.riple.scanner.testdata.SampleClassForTest$Inner",
                 "edu/ucr/cs/riple/scanner/SampleClassForTest.java"),
-            new ClassInfoDisplay(
+            new ClassRecordDisplay(
                 "edu.ucr.cs.riple.scanner.testdata.SampleClassForTest$1InnerMethod",
                 "edu/ucr/cs/riple/scanner/SampleClassForTest.java"),
-            new ClassInfoDisplay(
+            new ClassRecordDisplay(
                 "edu.ucr.cs.riple.scanner.testdata.SampleClassForTest$1InnerMethod$1",
                 "edu/ucr/cs/riple/scanner/SampleClassForTest.java"),
-            new ClassInfoDisplay(
+            new ClassRecordDisplay(
                 "edu.ucr.cs.riple.scanner.testdata.Run",
                 "edu/ucr/cs/riple/scanner/SampleClassForTest.java"))
         .doTest();

--- a/annotator-scanner/src/test/java/edu/ucr/cs/riple/scanner/ConfigurationTest.java
+++ b/annotator-scanner/src/test/java/edu/ucr/cs/riple/scanner/ConfigurationTest.java
@@ -25,7 +25,7 @@
 package edu.ucr.cs.riple.scanner;
 
 import com.google.errorprone.CompilationTestHelper;
-import edu.ucr.cs.riple.scanner.tools.ClassInfoDisplay;
+import edu.ucr.cs.riple.scanner.tools.ClassRecordDisplay;
 import edu.ucr.cs.riple.scanner.tools.Display;
 import edu.ucr.cs.riple.scanner.tools.DisplayFactory;
 import edu.ucr.cs.riple.scanner.tools.SerializationTestHelper;
@@ -59,7 +59,8 @@ public class ConfigurationTest {
 
   @Rule public final TemporaryFolder temporaryFolder = new TemporaryFolder();
   // Just a dummy factory to run the tests with, tests will not even start with a null factory.
-  protected DisplayFactory<Display> factory = values -> new ClassInfoDisplay("Unknown", "Unknown");
+  protected DisplayFactory<Display> factory =
+      values -> new ClassRecordDisplay("Unknown", "Unknown");
   protected SerializationTestHelper<Display> tester;
   protected Path root;
 

--- a/annotator-scanner/src/test/java/edu/ucr/cs/riple/scanner/MethodRecordTest.java
+++ b/annotator-scanner/src/test/java/edu/ucr/cs/riple/scanner/MethodRecordTest.java
@@ -26,16 +26,16 @@ package edu.ucr.cs.riple.scanner;
 
 import com.google.common.base.Preconditions;
 import edu.ucr.cs.riple.scanner.tools.DisplayFactory;
-import edu.ucr.cs.riple.scanner.tools.MethodInfoDisplay;
+import edu.ucr.cs.riple.scanner.tools.MethodRecordDisplay;
 import java.util.Arrays;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
 
 @RunWith(JUnit4.class)
-public class MethodRecordTest extends AnnotatorScannerBaseTest<MethodInfoDisplay> {
+public class MethodRecordTest extends AnnotatorScannerBaseTest<MethodRecordDisplay> {
 
-  private static final DisplayFactory<MethodInfoDisplay> METHOD_DISPLAY_FACTORY =
+  private static final DisplayFactory<MethodRecordDisplay> METHOD_DISPLAY_FACTORY =
       values -> {
         Preconditions.checkArgument(
             values.length == 9,
@@ -43,8 +43,8 @@ public class MethodRecordTest extends AnnotatorScannerBaseTest<MethodInfoDisplay
                 + values.length
                 + ", "
                 + Arrays.toString(values));
-        MethodInfoDisplay display =
-            new MethodInfoDisplay(
+        MethodRecordDisplay display =
+            new MethodRecordDisplay(
                 values[0], values[1], values[2], values[3], values[4], values[5], values[6],
                 values[7], values[8]);
         display.uri = display.uri.substring(display.uri.indexOf("edu/ucr/"));
@@ -81,7 +81,7 @@ public class MethodRecordTest extends AnnotatorScannerBaseTest<MethodInfoDisplay
             "   }",
             "}")
         .setExpectedOutputs(
-            new MethodInfoDisplay(
+            new MethodRecordDisplay(
                 "1",
                 "edu.ucr.A",
                 "returnNonNull()",
@@ -114,7 +114,7 @@ public class MethodRecordTest extends AnnotatorScannerBaseTest<MethodInfoDisplay
             "   }",
             "}")
         .setExpectedOutputs(
-            new MethodInfoDisplay(
+            new MethodRecordDisplay(
                 "1",
                 "edu.ucr.A",
                 "returnNonNull()",
@@ -124,7 +124,7 @@ public class MethodRecordTest extends AnnotatorScannerBaseTest<MethodInfoDisplay
                 "public",
                 "true",
                 "edu/ucr/A.java"),
-            new MethodInfoDisplay(
+            new MethodRecordDisplay(
                 "2",
                 "edu.ucr.B",
                 "returnNonNull()",
@@ -158,7 +158,7 @@ public class MethodRecordTest extends AnnotatorScannerBaseTest<MethodInfoDisplay
             "   }",
             "}")
         .setExpectedOutputs(
-            new MethodInfoDisplay(
+            new MethodRecordDisplay(
                 "1",
                 "edu.ucr.A",
                 "publicMethod()",
@@ -168,7 +168,7 @@ public class MethodRecordTest extends AnnotatorScannerBaseTest<MethodInfoDisplay
                 "public",
                 "true",
                 "edu/ucr/A.java"),
-            new MethodInfoDisplay(
+            new MethodRecordDisplay(
                 "2",
                 "edu.ucr.A",
                 "privateMethod()",
@@ -178,7 +178,7 @@ public class MethodRecordTest extends AnnotatorScannerBaseTest<MethodInfoDisplay
                 "private",
                 "true",
                 "edu/ucr/A.java"),
-            new MethodInfoDisplay(
+            new MethodRecordDisplay(
                 "3",
                 "edu.ucr.A",
                 "protectedMethod()",
@@ -188,7 +188,7 @@ public class MethodRecordTest extends AnnotatorScannerBaseTest<MethodInfoDisplay
                 "protected",
                 "true",
                 "edu/ucr/A.java"),
-            new MethodInfoDisplay(
+            new MethodRecordDisplay(
                 "4",
                 "edu.ucr.A",
                 "packageMethod()",
@@ -225,7 +225,7 @@ public class MethodRecordTest extends AnnotatorScannerBaseTest<MethodInfoDisplay
             "   }",
             "}")
         .setExpectedOutputs(
-            new MethodInfoDisplay(
+            new MethodRecordDisplay(
                 "1",
                 "edu.ucr.A",
                 "publicMethod()",
@@ -235,7 +235,7 @@ public class MethodRecordTest extends AnnotatorScannerBaseTest<MethodInfoDisplay
                 "package",
                 "true",
                 "edu/ucr/A.java"),
-            new MethodInfoDisplay(
+            new MethodRecordDisplay(
                 "2",
                 "edu.ucr.A",
                 "publicAbstractMethod()",
@@ -245,9 +245,9 @@ public class MethodRecordTest extends AnnotatorScannerBaseTest<MethodInfoDisplay
                 "public",
                 "true",
                 "edu/ucr/A.java"),
-            new MethodInfoDisplay(
+            new MethodRecordDisplay(
                 "3", "edu.ucr.B", "foo()", "0", "[]", "false", "public", "false", "edu/ucr/B.java"),
-            new MethodInfoDisplay(
+            new MethodRecordDisplay(
                 "4", "edu.ucr.B", "run()", "0", "[]", "true", "public", "true", "edu/ucr/B.java"))
         .doTest();
   }

--- a/annotator-scanner/src/test/java/edu/ucr/cs/riple/scanner/tools/ClassRecordDisplay.java
+++ b/annotator-scanner/src/test/java/edu/ucr/cs/riple/scanner/tools/ClassRecordDisplay.java
@@ -26,12 +26,12 @@ package edu.ucr.cs.riple.scanner.tools;
 
 import java.util.Objects;
 
-public class ClassInfoDisplay implements Display {
+public class ClassRecordDisplay implements Display {
 
   public final String clazz;
   public String path;
 
-  public ClassInfoDisplay(String clazz, String path) {
+  public ClassRecordDisplay(String clazz, String path) {
     this.clazz = clazz;
     this.path = path;
   }
@@ -41,10 +41,10 @@ public class ClassInfoDisplay implements Display {
     if (this == o) {
       return true;
     }
-    if (!(o instanceof ClassInfoDisplay)) {
+    if (!(o instanceof ClassRecordDisplay)) {
       return false;
     }
-    ClassInfoDisplay that = (ClassInfoDisplay) o;
+    ClassRecordDisplay that = (ClassRecordDisplay) o;
     return clazz.equals(that.clazz) && path.equals(that.path);
   }
 

--- a/annotator-scanner/src/test/java/edu/ucr/cs/riple/scanner/tools/MethodRecordDisplay.java
+++ b/annotator-scanner/src/test/java/edu/ucr/cs/riple/scanner/tools/MethodRecordDisplay.java
@@ -26,7 +26,7 @@ package edu.ucr.cs.riple.scanner.tools;
 
 import java.util.Objects;
 
-public class MethodInfoDisplay implements Display {
+public class MethodRecordDisplay implements Display {
 
   public final String id;
   public final String clazz;
@@ -38,7 +38,7 @@ public class MethodInfoDisplay implements Display {
   public final String hasNonPrimitiveReturn;
   public String uri;
 
-  public MethodInfoDisplay(
+  public MethodRecordDisplay(
       String id,
       String clazz,
       String symbol,
@@ -64,10 +64,10 @@ public class MethodInfoDisplay implements Display {
     if (this == o) {
       return true;
     }
-    if (!(o instanceof MethodInfoDisplay)) {
+    if (!(o instanceof MethodRecordDisplay)) {
       return false;
     }
-    MethodInfoDisplay that = (MethodInfoDisplay) o;
+    MethodRecordDisplay that = (MethodRecordDisplay) o;
     return Objects.equals(clazz, that.clazz)
         && Objects.equals(symbol, that.symbol)
         && Objects.equals(parent, that.parent)


### PR DESCRIPTION
Followup to PR #195, this PR renames remaining classes in `test` directory. It renames `MethodInfoDisplay` to `MethodRecordDisplay` and `ClassInfoDisplay` to `ClassRecordDisplay`.