### PR TITLE
Collect std out using Redirect.INHERIT API

### DIFF
--- a/annotator-core/src/main/java/edu/ucr/cs/riple/core/util/Utility.java
+++ b/annotator-core/src/main/java/edu/ucr/cs/riple/core/util/Utility.java
@@ -67,7 +67,7 @@ public class Utility {
    */
   public static void executeCommand(Config config, String command) {
     try {
-      ProcessBuilder pb = new ProcessBuilder(command);
+      ProcessBuilder pb = new ProcessBuilder("/bin/sh", "-c", command);
       if (config.redirectBuildOutputToStdErr) {
         pb.redirectError(ProcessBuilder.Redirect.INHERIT);
         pb.redirectOutput(ProcessBuilder.Redirect.INHERIT);

--- a/annotator-core/src/main/java/edu/ucr/cs/riple/core/util/Utility.java
+++ b/annotator-core/src/main/java/edu/ucr/cs/riple/core/util/Utility.java
@@ -71,7 +71,7 @@ public class Utility {
       if (config.redirectBuildOutputToStdErr) {
         pb.redirectError(ProcessBuilder.Redirect.INHERIT);
         pb.redirectOutput(ProcessBuilder.Redirect.INHERIT);
-      }else {
+      } else {
         // to avoid buffer filling up
         pb.redirectError(ProcessBuilder.Redirect.DISCARD);
         pb.redirectOutput(ProcessBuilder.Redirect.DISCARD);

--- a/annotator-core/src/main/java/edu/ucr/cs/riple/core/util/Utility.java
+++ b/annotator-core/src/main/java/edu/ucr/cs/riple/core/util/Utility.java
@@ -71,6 +71,10 @@ public class Utility {
       if (config.redirectBuildOutputToStdErr) {
         pb.redirectError(ProcessBuilder.Redirect.INHERIT);
         pb.redirectOutput(ProcessBuilder.Redirect.INHERIT);
+      }else {
+        // to avoid buffer filling up
+        pb.redirectError(ProcessBuilder.Redirect.DISCARD);
+        pb.redirectOutput(ProcessBuilder.Redirect.DISCARD);
       }
       pb.start().waitFor();
     } catch (Exception e) {

--- a/annotator-core/src/main/java/edu/ucr/cs/riple/core/util/Utility.java
+++ b/annotator-core/src/main/java/edu/ucr/cs/riple/core/util/Utility.java
@@ -38,10 +38,8 @@ import edu.ucr.cs.riple.core.module.ModuleInfo;
 import edu.ucr.cs.riple.scanner.AnnotatorScanner;
 import edu.ucr.cs.riple.scanner.ScannerConfigWriter;
 import edu.ucr.cs.riple.scanner.generatedcode.SourceType;
-import java.io.BufferedReader;
 import java.io.BufferedWriter;
 import java.io.IOException;
-import java.io.InputStreamReader;
 import java.nio.charset.Charset;
 import java.nio.file.Files;
 import java.nio.file.Path;
@@ -69,16 +67,12 @@ public class Utility {
    */
   public static void executeCommand(Config config, String command) {
     try {
-      Process p = Runtime.getRuntime().exec(new String[] {"/bin/sh", "-c", command});
-      BufferedReader reader =
-          new BufferedReader(new InputStreamReader(p.getErrorStream(), Charset.defaultCharset()));
-      String line;
-      while ((line = reader.readLine()) != null) {
-        if (config.redirectBuildOutputToStdErr) {
-          System.err.println(line);
-        }
+      ProcessBuilder pb = new ProcessBuilder(command);
+      if (config.redirectBuildOutputToStdErr) {
+        pb.redirectError(ProcessBuilder.Redirect.INHERIT);
+        pb.redirectOutput(ProcessBuilder.Redirect.INHERIT);
       }
-      p.waitFor();
+      pb.start().waitFor();
     } catch (Exception e) {
       throw new RuntimeException("Exception happened in executing command: " + command, e);
     }


### PR DESCRIPTION
Resolves #205. This PR refactors std error output collection by using `Redirect.INHERIT` API. It also adds collecting std out of the child process (module builds) and prints them along the std error if `-rboserr` is set.