### PR TITLE
Disable signing for all publishes

### DIFF
--- a/annotator-core/build.gradle
+++ b/annotator-core/build.gradle
@@ -76,7 +76,6 @@ publishing {
 
     mavenPublishing {
         publishToMavenCentral(SonatypeHost.S01)
-        signAllPublications()
     }
 
     repositories {

--- a/annotator-scanner/build.gradle
+++ b/annotator-scanner/build.gradle
@@ -53,6 +53,5 @@ dependencies {
 publishing {
     mavenPublishing {
         publishToMavenCentral(SonatypeHost.S01)
-        signAllPublications()
     }
 }

--- a/gradle.properties
+++ b/gradle.properties
@@ -39,3 +39,6 @@ POM_LICENCE_DIST=repo
 POM_DEVELOPER_ID=ucr-riple
 POM_DEVELOPER_NAME=PLSE research at UC Riverside
 POM_DEVELOPER_URL=https://riple.cs.ucr.edu
+
+# Pass ORG_GRADLE_PROJECT_RELEASE_SIGNING_ENABLED=false for local releases to disable signing
+RELEASE_SIGNING_ENABLED=true


### PR DESCRIPTION
This PR removes `signAllPublications` for publish scripts and adds `RELEASE_SIGNING_ENABLED` flag to `gradle.properties`. This will allow us to control signing requirement using `ORG_GRADLE_PROJECT_RELEASE_SIGNING_ENABLED` flag while making local releases.