### PR TITLE
Update tests to compute distinct build command for target and downstream depenedencies

### DIFF
--- a/annotator-core/src/main/java/edu/ucr/cs/riple/core/evaluators/suppliers/DownstreamDependencySupplier.java
+++ b/annotator-core/src/main/java/edu/ucr/cs/riple/core/evaluators/suppliers/DownstreamDependencySupplier.java
@@ -51,7 +51,10 @@ public class DownstreamDependencySupplier extends AbstractSupplier {
   public DownstreamDependencySupplier(Context context) {
     super(
         context,
-        new ModuleInfo(context, context.downstreamConfigurations, context.config.buildCommand));
+        new ModuleInfo(
+            context,
+            context.downstreamConfigurations,
+            context.config.downstreamDependenciesBuildCommand));
   }
 
   @Override

--- a/annotator-core/src/test/java/edu/ucr/cs/riple/core/tools/CoreTestHelper.java
+++ b/annotator-core/src/test/java/edu/ucr/cs/riple/core/tools/CoreTestHelper.java
@@ -407,8 +407,10 @@ public class CoreTestHelper {
         !getEnvironmentVariable("ANNOTATOR_TEST_DISABLE_PARALLEL_PROCESSING");
     if (downstreamDependencyAnalysisActivated) {
       builder.buildCommand =
-          projectBuilder.computeBuildCommandWithLibraryModelLoaderDependency(this.outDirPath);
-      builder.downstreamBuildCommand = builder.buildCommand;
+          projectBuilder.computeTargetBuildCommandWithLibraryModelLoaderDependency(this.outDirPath);
+      builder.downstreamBuildCommand =
+          projectBuilder.computeDownstreamDependencyBuildCommandWithLibraryModelLoaderDependency(
+              this.outDirPath);
       builder.nullawayLibraryModelLoaderPath =
           Utility.getPathToLibraryModel(outDirPath)
               .resolve(
@@ -423,7 +425,7 @@ public class CoreTestHelper {
                       "librarymodel",
                       "nullable-methods.tsv"));
     } else {
-      builder.buildCommand = projectBuilder.computeBuildCommand(this.outDirPath);
+      builder.buildCommand = projectBuilder.computeTargetBuildCommand(this.outDirPath);
     }
     builder.write(configPath);
   }


### PR DESCRIPTION
This PR updates tests infrastructure to compute distinct commands for building target and downstream dependencies. This will reveal a bug in the implementation which is also fixed in this PR.