### PR TITLE
Updates method signature serialization for Nonull formal parameters

### DIFF
--- a/annotator-core/src/test/java/edu/ucr/cs/riple/core/CoreTest.java
+++ b/annotator-core/src/test/java/edu/ucr/cs/riple/core/CoreTest.java
@@ -558,7 +558,7 @@ public class CoreTest extends AnnotatorBaseCoreTest {
   }
 
   @Test
-  public void nonnullTypeUseAcknowledgmentTest() {
+  public void nonnullTypeUseAnnotationOnFormalParameterAcknowledgmentTest() {
     coreTestHelper
         .onTarget()
         .withSourceLines(

--- a/annotator-core/src/test/java/edu/ucr/cs/riple/core/CoreTest.java
+++ b/annotator-core/src/test/java/edu/ucr/cs/riple/core/CoreTest.java
@@ -566,7 +566,8 @@ public class CoreTest extends AnnotatorBaseCoreTest {
             "package test;",
             "import org.jetbrains.annotations.NotNull;",
             "public class A {",
-            "   private @NotNull Object field;",
+            "  static void foo(@NotNull Object o) {}",
+            "  static void bar() { foo(null); }",
             "}")
         .expectNoReport()
         .toDepth(5)

--- a/annotator-core/src/test/java/edu/ucr/cs/riple/core/CoreTest.java
+++ b/annotator-core/src/test/java/edu/ucr/cs/riple/core/CoreTest.java
@@ -558,21 +558,20 @@ public class CoreTest extends AnnotatorBaseCoreTest {
   }
 
   @Test
-  public void nonnullTypeUseAcknowledgmentTest(){
+  public void nonnullTypeUseAcknowledgmentTest() {
     coreTestHelper
-            .onTarget()
-            .withSourceLines(
-                    "A.java",
-                    "package test;",
-                    "import org.jetbrains.annotations.NotNull;",
-                    "public class A {",
-                    "   private @NotNull Object field;",
-                    "}")
-            .expectNoReport()
-            .toDepth(5)
-            .start();
-    // No annotation should be added, since they are annotated as @Nonnull although each can reduce
-    // the number of errors.
+        .onTarget()
+        .withSourceLines(
+            "A.java",
+            "package test;",
+            "import org.jetbrains.annotations.NotNull;",
+            "public class A {",
+            "   private @NotNull Object field;",
+            "}")
+        .expectNoReport()
+        .toDepth(5)
+        .start();
+    // No annotation should be added even though it can reduce the number of errors.
     Assert.assertEquals(coreTestHelper.getLog().getInjectedAnnotations().size(), 0);
   }
 }

--- a/annotator-core/src/test/java/edu/ucr/cs/riple/core/CoreTest.java
+++ b/annotator-core/src/test/java/edu/ucr/cs/riple/core/CoreTest.java
@@ -556,4 +556,23 @@ public class CoreTest extends AnnotatorBaseCoreTest {
         .toDepth(1)
         .start();
   }
+
+  @Test
+  public void nonnullTypeUseAcknowledgmentTest(){
+    coreTestHelper
+            .onTarget()
+            .withSourceLines(
+                    "A.java",
+                    "package test;",
+                    "import org.jetbrains.annotations.NotNull;",
+                    "public class A {",
+                    "   private @NotNull Object field;",
+                    "}")
+            .expectNoReport()
+            .toDepth(5)
+            .start();
+    // No annotation should be added, since they are annotated as @Nonnull although each can reduce
+    // the number of errors.
+    Assert.assertEquals(coreTestHelper.getLog().getInjectedAnnotations().size(), 0);
+  }
 }

--- a/annotator-core/src/test/java/edu/ucr/cs/riple/core/tools/CoreTestHelper.java
+++ b/annotator-core/src/test/java/edu/ucr/cs/riple/core/tools/CoreTestHelper.java
@@ -402,9 +402,8 @@ public class CoreTestHelper {
     builder.useCacheImpact = true;
     builder.sourceTypes.add(SourceType.LOMBOK);
     builder.cache = true;
-    builder.useCacheImpact = !getEnvironmentVariable("ANNOTATOR_TEST_DISABLE_CACHING");
-    builder.useParallelProcessor =
-        !getEnvironmentVariable("ANNOTATOR_TEST_DISABLE_PARALLEL_PROCESSING");
+    builder.useCacheImpact = false;
+    builder.useParallelProcessor = true;
     if (downstreamDependencyAnalysisActivated) {
       builder.buildCommand =
           projectBuilder.computeTargetBuildCommandWithLibraryModelLoaderDependency(this.outDirPath);

--- a/annotator-core/src/test/java/edu/ucr/cs/riple/core/tools/CoreTestHelper.java
+++ b/annotator-core/src/test/java/edu/ucr/cs/riple/core/tools/CoreTestHelper.java
@@ -402,8 +402,9 @@ public class CoreTestHelper {
     builder.useCacheImpact = true;
     builder.sourceTypes.add(SourceType.LOMBOK);
     builder.cache = true;
-    builder.useCacheImpact = false;
-    builder.useParallelProcessor = true;
+    builder.useCacheImpact = !getEnvironmentVariable("ANNOTATOR_TEST_DISABLE_CACHING");
+    builder.useParallelProcessor =
+        !getEnvironmentVariable("ANNOTATOR_TEST_DISABLE_PARALLEL_PROCESSING");
     if (downstreamDependencyAnalysisActivated) {
       builder.buildCommand =
           projectBuilder.computeTargetBuildCommandWithLibraryModelLoaderDependency(this.outDirPath);

--- a/annotator-core/src/test/resources/templates/nullable-multi-modular/build.gradle
+++ b/annotator-core/src/test/resources/templates/nullable-multi-modular/build.gradle
@@ -53,6 +53,8 @@ subprojects {
 
         // to add @Initializer
         compileOnly 'com.uber.nullaway:nullaway-annotations:0.10.10'
+        // to add jetbrains annotations (testing type use vs type declaration)
+        compileOnly 'org.jetbrains:annotations:24.0.0'
         compileOnly "org.jspecify:jspecify:0.3.0"
         compileOnly "com.google.code.findbugs:jsr305:3.0.2"
         errorprone "com.google.errorprone:error_prone_core:2.3.2"

--- a/annotator-scanner/src/main/java/edu/ucr/cs/riple/scanner/location/MethodParameterLocation.java
+++ b/annotator-scanner/src/main/java/edu/ucr/cs/riple/scanner/location/MethodParameterLocation.java
@@ -24,6 +24,7 @@ package edu.ucr.cs.riple.scanner.location;
 
 import com.google.common.base.Preconditions;
 import com.sun.tools.javac.code.Symbol;
+import edu.ucr.cs.riple.scanner.Serializer;
 import javax.lang.model.element.ElementKind;
 
 /**
@@ -66,8 +67,8 @@ public class MethodParameterLocation extends AbstractSymbolLocation {
         "\t",
         type.toString(),
         enclosingClass.flatName(),
-        enclosingMethod.toString(),
-        paramSymbol.toString(),
+        Serializer.serializeSymbol(enclosingMethod),
+        Serializer.serializeSymbol(paramSymbol),
         String.valueOf(index),
         path != null ? path.toString() : "null");
   }


### PR DESCRIPTION
This PR fixes #212 by updating method signature serialization for nonnull formal parameters. It reuses the existing serialization methods for symbols that ensure the correct method signature is printed.