### PR TITLE
Updates symbol serialization in all Location subclasses in Scanner

### DIFF
--- a/annotator-scanner/src/main/java/edu/ucr/cs/riple/scanner/location/FieldLocation.java
+++ b/annotator-scanner/src/main/java/edu/ucr/cs/riple/scanner/location/FieldLocation.java
@@ -23,6 +23,7 @@
 package edu.ucr.cs.riple.scanner.location;
 
 import com.sun.tools.javac.code.Symbol;
+import edu.ucr.cs.riple.scanner.Serializer;
 import javax.lang.model.element.ElementKind;
 
 /**
@@ -44,9 +45,9 @@ public class FieldLocation extends AbstractSymbolLocation {
     return String.join(
         "\t",
         type.toString(),
-        enclosingClass.flatName(),
+        Serializer.serializeSymbol(enclosingClass),
         "null",
-        variableSymbol.toString(),
+        Serializer.serializeSymbol(variableSymbol),
         "null",
         path != null ? path.toString() : "null");
   }

--- a/annotator-scanner/src/main/java/edu/ucr/cs/riple/scanner/location/MethodLocation.java
+++ b/annotator-scanner/src/main/java/edu/ucr/cs/riple/scanner/location/MethodLocation.java
@@ -23,6 +23,8 @@
 package edu.ucr.cs.riple.scanner.location;
 
 import com.sun.tools.javac.code.Symbol;
+import edu.ucr.cs.riple.scanner.Serializer;
+
 import javax.lang.model.element.ElementKind;
 
 /**
@@ -45,7 +47,7 @@ public class MethodLocation extends AbstractSymbolLocation {
         "\t",
         type.toString(),
         enclosingClass.flatName(),
-        enclosingMethod.toString(),
+        Serializer.serializeSymbol(enclosingMethod),
         "null",
         "null",
         path != null ? path.toString() : "null");

--- a/annotator-scanner/src/main/java/edu/ucr/cs/riple/scanner/location/MethodLocation.java
+++ b/annotator-scanner/src/main/java/edu/ucr/cs/riple/scanner/location/MethodLocation.java
@@ -45,7 +45,7 @@ public class MethodLocation extends AbstractSymbolLocation {
     return String.join(
         "\t",
         type.toString(),
-        enclosingClass.flatName(),
+        Serializer.serializeSymbol(enclosingClass),
         Serializer.serializeSymbol(enclosingMethod),
         "null",
         "null",

--- a/annotator-scanner/src/main/java/edu/ucr/cs/riple/scanner/location/MethodLocation.java
+++ b/annotator-scanner/src/main/java/edu/ucr/cs/riple/scanner/location/MethodLocation.java
@@ -24,7 +24,6 @@ package edu.ucr.cs.riple.scanner.location;
 
 import com.sun.tools.javac.code.Symbol;
 import edu.ucr.cs.riple.scanner.Serializer;
-
 import javax.lang.model.element.ElementKind;
 
 /**

--- a/annotator-scanner/src/main/java/edu/ucr/cs/riple/scanner/location/MethodParameterLocation.java
+++ b/annotator-scanner/src/main/java/edu/ucr/cs/riple/scanner/location/MethodParameterLocation.java
@@ -66,7 +66,7 @@ public class MethodParameterLocation extends AbstractSymbolLocation {
     return String.join(
         "\t",
         type.toString(),
-        enclosingClass.flatName(),
+        Serializer.serializeSymbol(enclosingClass),
         Serializer.serializeSymbol(enclosingMethod),
         Serializer.serializeSymbol(paramSymbol),
         String.valueOf(index),


### PR DESCRIPTION
Followup to #213, this PR fixes symbol serialization in all `Location` subclasses.