### PR TITLE
Clean up in annotator core test configuration

### DIFF
--- a/annotator-core/build.gradle
+++ b/annotator-core/build.gradle
@@ -92,26 +92,3 @@ jar {
 shadowJar {
     archiveClassifier = null
 }
-
-// Configure test environment
-def nullawayVersionMap = [0:"0.10.4", 1:"0.10.5"]
-tasks.register("configureNullAwayVersion"){
-    if(!project.hasProperty("nullaway-serialization-format-version")){
-        return
-    }
-    NULLAWAY_TEST = nullawayVersionMap.get((project.getProperty("nullaway-serialization-format-version")) as int)
-    println "NullAway Test version changed to: " + NULLAWAY_TEST
-
-    // exclude unsupported tests below...
-    switch (NULLAWAY_TEST){
-        case "0.10.4":
-            test {
-                filter {
-                    excludeTest "edu.ucr.cs.riple.core.CoreTest", "errorInFieldDeclarationSuppressRemainingErrorsTest"
-                    excludeTest "edu.ucr.cs.riple.core.CoreTest", "initializationErrorWithMultipleConstructors"
-                }
-            }
-            break
-    }
-}
-tasks.test.dependsOn("configureNullAwayVersion")


### PR DESCRIPTION
We no longer have tests incompatible with older versions of NullAway. All our tests are compatible with latest supporting version of NullAway (0.10.19). This PR clean ups our test configuration.