### PR TITLE
Add support for fixes on record declarations

### DIFF
--- a/annotator-core/src/test/java/edu/ucr/cs/riple/core/Java17Test.java
+++ b/annotator-core/src/test/java/edu/ucr/cs/riple/core/Java17Test.java
@@ -26,6 +26,7 @@ package edu.ucr.cs.riple.core;
 
 import edu.ucr.cs.riple.core.tools.TReport;
 import edu.ucr.cs.riple.injector.location.OnField;
+import edu.ucr.cs.riple.injector.location.OnMethod;
 import java.util.Set;
 import org.junit.Test;
 
@@ -55,6 +56,24 @@ public class Java17Test extends AnnotatorBaseCoreTest {
             "}")
         .withExpectedReports(
             new TReport(new OnField("Main.java", "test.Main", Set.of("f1", "f2", "f3", "f4")), -4))
+        .start();
+  }
+
+  @Test
+  public void recordDeclarationTest() {
+    coreTestHelper
+        .onTarget()
+        .withSourceLines(
+            "A.java",
+            "package test;",
+            "public record A(String name) {",
+            "  public static A create(String name) {",
+            "      return null;",
+            "  }",
+            "}")
+        .withExpectedReports(
+            new TReport(new OnMethod("A.java", "test.A", "create(java.lang.String)"), -1))
+        .toDepth(5)
         .start();
   }
 }

--- a/injector/src/main/java/edu/ucr/cs/riple/injector/Helper.java
+++ b/injector/src/main/java/edu/ucr/cs/riple/injector/Helper.java
@@ -35,6 +35,7 @@ import com.github.javaparser.ast.body.EnumDeclaration;
 import com.github.javaparser.ast.body.FieldDeclaration;
 import com.github.javaparser.ast.body.MethodDeclaration;
 import com.github.javaparser.ast.body.Parameter;
+import com.github.javaparser.ast.body.RecordDeclaration;
 import com.github.javaparser.ast.body.TypeDeclaration;
 import com.github.javaparser.ast.body.VariableDeclarator;
 import com.github.javaparser.ast.expr.AnnotationExpr;
@@ -143,6 +144,10 @@ public class Helper {
     Optional<ClassOrInterfaceDeclaration> interfaceDeclaration = tree.getInterfaceByName(name);
     if (interfaceDeclaration.isPresent()) {
       return interfaceDeclaration.get();
+    }
+    Optional<RecordDeclaration> recordDeclaration = tree.getRecordByName(name);
+    if (recordDeclaration.isPresent()) {
+      return recordDeclaration.get();
     }
     throw new TargetClassNotFound("Top-Level", name, tree);
   }
@@ -284,6 +289,9 @@ public class Helper {
     }
     if (node instanceof EnumConstantDeclaration) {
       return ((EnumConstantDeclaration) node).getClassBody();
+    }
+    if (node instanceof RecordDeclaration) {
+      return ((RecordDeclaration) node).getMembers();
     }
     return null;
   }


### PR DESCRIPTION
Fixes #225 . This is a follow up on #223 which adds support for processing source code written in java `17`. However, it was observed that support for modifications to `record` declarations were left out. This pull request addresses this issue.