### PR TITLE
Optimize field registry population mechanism by parsing each source file only once

### DIFF
--- a/annotator-core/src/main/java/edu/ucr/cs/riple/core/registries/field/FieldRegistry.java
+++ b/annotator-core/src/main/java/edu/ucr/cs/riple/core/registries/field/FieldRegistry.java
@@ -110,9 +110,10 @@ public class FieldRegistry extends Registry<ClassFieldRecord> {
           // Already visited.
           tree = lastParsedSourceFile.b;
         } else {
+          // Not visited yet, parse the source file.
           tree = Injector.parse(path);
+          lastParsedSourceFile = new Pair<>(path, tree);
         }
-        lastParsedSourceFile = new Pair<>(path, tree);
         if (tree == null) {
           return null;
         }

--- a/annotator-core/src/main/java/edu/ucr/cs/riple/core/registries/field/FieldRegistry.java
+++ b/annotator-core/src/main/java/edu/ucr/cs/riple/core/registries/field/FieldRegistry.java
@@ -94,14 +94,15 @@ public class FieldRegistry extends Registry<ClassFieldRecord> {
   @Override
   protected Builder<ClassFieldRecord> getBuilder() {
     return new Builder<>() {
-      // This method is called with a pair of a class flat name and a path to source file containing
-      // the class. To avoid parsing a source file multiple times, we keep the last parsed
-      // source file in a reference. This optimization is according to the assumption that Scanner
-      // visits all classes within a single compilation unit tree consecutively.
       Pair<Path, CompilationUnit> lastParsedSourceFile = new Pair<>(null, null);
 
       @Override
       public ClassFieldRecord build(String[] values) {
+        // This method is called with values in format of: [class flat name, path to source file].
+        // To avoid parsing a source file multiple times, we keep the last parsed
+        // source file in a reference.
+        // This optimization is according to the assumption that Scanner
+        // visits all classes within a single compilation unit tree consecutively.
         // Path to class.
         Path path = Helper.deserializePath(values[1]);
         CompilationUnit tree;

--- a/annotator-core/src/main/java/edu/ucr/cs/riple/core/registries/field/FieldRegistry.java
+++ b/annotator-core/src/main/java/edu/ucr/cs/riple/core/registries/field/FieldRegistry.java
@@ -43,6 +43,7 @@ import edu.ucr.cs.riple.injector.location.OnField;
 import edu.ucr.cs.riple.scanner.Serializer;
 import java.nio.file.Path;
 import java.util.Collections;
+import java.util.HashSet;
 import java.util.Optional;
 import java.util.Set;
 import javax.annotation.Nullable;
@@ -92,16 +93,23 @@ public class FieldRegistry extends Registry<ClassFieldRecord> {
 
   @Override
   protected Builder<ClassFieldRecord> getBuilder() {
+    // Parsed source files.
+    final Set<Path> visited = new HashSet<>();
     return values -> {
-      // Class flat name.
-      String clazz = values[0];
       // Path to class.
       Path path = Helper.deserializePath(values[1]);
+      if (visited.contains(path)) {
+        // Already visited.
+        return null;
+      }
+      visited.add(path);
       CompilationUnit tree = Injector.parse(path);
       if (tree == null) {
         return null;
       }
       NodeList<BodyDeclaration<?>> members;
+      // Class flat name.
+      String clazz = values[0];
       try {
         members = Helper.getTypeDeclarationMembersByFlatName(tree, clazz);
       } catch (TargetClassNotFound notFound) {

--- a/annotator-core/src/test/java/edu/ucr/cs/riple/core/CoreTest.java
+++ b/annotator-core/src/test/java/edu/ucr/cs/riple/core/CoreTest.java
@@ -575,4 +575,26 @@ public class CoreTest extends AnnotatorBaseCoreTest {
     // No annotation should be added even though it can reduce the number of errors.
     Assert.assertEquals(coreTestHelper.getLog().getInjectedAnnotations().size(), 0);
   }
+
+  @Test
+  public void aaaaaa() {
+    coreTestHelper
+        .onTarget()
+        .withSourceLines(
+            "A.java",
+            "package test;",
+            "import org.jetbrains.annotations.NotNull;",
+            "public class A {",
+            "  class B1 {}",
+            "  class B2 {}",
+            "  class B3 {}",
+            "  class B4 {}",
+            "  class B5 {}",
+            "}")
+        .expectNoReport()
+        .toDepth(5)
+        .start();
+    // No annotation should be added even though it can reduce the number of errors.
+    Assert.assertEquals(coreTestHelper.getLog().getInjectedAnnotations().size(), 0);
+  }
 }

--- a/annotator-core/src/test/java/edu/ucr/cs/riple/core/CoreTest.java
+++ b/annotator-core/src/test/java/edu/ucr/cs/riple/core/CoreTest.java
@@ -575,26 +575,4 @@ public class CoreTest extends AnnotatorBaseCoreTest {
     // No annotation should be added even though it can reduce the number of errors.
     Assert.assertEquals(coreTestHelper.getLog().getInjectedAnnotations().size(), 0);
   }
-
-  @Test
-  public void aaaaaa() {
-    coreTestHelper
-        .onTarget()
-        .withSourceLines(
-            "A.java",
-            "package test;",
-            "import org.jetbrains.annotations.NotNull;",
-            "public class A {",
-            "  class B1 {}",
-            "  class B2 {}",
-            "  class B3 {}",
-            "  class B4 {}",
-            "  class B5 {}",
-            "}")
-        .expectNoReport()
-        .toDepth(5)
-        .start();
-    // No annotation should be added even though it can reduce the number of errors.
-    Assert.assertEquals(coreTestHelper.getLog().getInjectedAnnotations().size(), 0);
-  }
 }


### PR DESCRIPTION
In [FieldRegistryPopulation](https://github.com/ucr-riple/NullAwayAnnotator/blob/6c17b8bccb08517f5ce3249d3285405ceeb47748/annotator-core/src/main/java/edu/ucr/cs/riple/core/registries/field/FieldRegistry.java#L97) we process a single compilation unit tree multiple times as this method receives a pair of a class flat name and a path to source file containing that class, hence, for compilation unit trees that contains multiple classes, inner classes and anonymous classes we parse the same source file multiple times. This PR updates this mechanism by caching the latest parsed source file. This optimization is according to the assumption that Scanner visits all classes within a single compilation unit tree consecutively.