### PR TITLE
Add a language level option for parsing

### DIFF
--- a/annotator-core/src/main/java/edu/ucr/cs/riple/core/Config.java
+++ b/annotator-core/src/main/java/edu/ucr/cs/riple/core/Config.java
@@ -153,9 +153,7 @@ public class Config {
    */
   public final String checkerName;
 
-  /**
-   * Language level to use when parsing Java code.  Defaults to Java 11.
-   */
+  /** Language level to use when parsing Java code. Defaults to Java 11. */
   public final ParserConfiguration.LanguageLevel languageLevel;
 
   /**
@@ -355,11 +353,11 @@ public class Config {
 
     // Language level to use when parsing
     Option languageLevel =
-            new Option(
-                    "ll",
-                    "language-level",
-                    false,
-                    "Java language level to use when parsing code. Supported values are 11 and 17.  Defaults to 11.");
+        new Option(
+            "ll",
+            "language-level",
+            false,
+            "Java language level to use when parsing code. Supported values are 11 and 17.  Defaults to 11.");
     languageLevel.setRequired(false);
     options.addOption(languageLevel);
 
@@ -471,7 +469,8 @@ public class Config {
             : ImmutableSet.copyOf(cmd.getOptionValue(nonnullAnnotationsOption).split(","));
   }
 
-  private ParserConfiguration.LanguageLevel getLanguageLevel(CommandLine cmd, Option languageLevel) {
+  private ParserConfiguration.LanguageLevel getLanguageLevel(
+      CommandLine cmd, Option languageLevel) {
     String languageLevelString = cmd.getOptionValue(languageLevel, "11");
     switch (languageLevelString) {
       case "11":

--- a/annotator-core/src/main/java/edu/ucr/cs/riple/core/Config.java
+++ b/annotator-core/src/main/java/edu/ucr/cs/riple/core/Config.java
@@ -357,7 +357,7 @@ public class Config {
             "ll",
             "language-level",
             true,
-            "Java language level to use when parsing code. Supported values are 11 and 17.  Defaults to 11.");
+            "Java language level to use when parsing code. Supported values are 11 and 17.  Defaults to 17.");
     languageLevelOption.setRequired(false);
     options.addOption(languageLevelOption);
 

--- a/annotator-core/src/main/java/edu/ucr/cs/riple/core/Config.java
+++ b/annotator-core/src/main/java/edu/ucr/cs/riple/core/Config.java
@@ -153,7 +153,7 @@ public class Config {
    */
   public final String checkerName;
 
-  /** Language level to use when parsing Java code. Defaults to Java 11. */
+  /** Language level to use when parsing Java code. Defaults to Java 17. */
   public final ParserConfiguration.LanguageLevel languageLevel;
 
   /**
@@ -462,7 +462,7 @@ public class Config {
         cmd.hasOption(disableRegionDetectionByLombok)
             ? ImmutableSet.of()
             : Sets.immutableEnumSet(SourceType.LOMBOK);
-    this.languageLevel = getLanguageLevel(cmd.getOptionValue(languageLevel, "11"));
+    this.languageLevel = getLanguageLevel(cmd.getOptionValue(languageLevel, "17"));
     this.nonnullAnnotations =
         !cmd.hasOption(nonnullAnnotationsOption)
             ? ImmutableSet.of()
@@ -573,7 +573,7 @@ public class Config {
     this.generatedCodeDetectors =
         lombokCodeDetectorActivated ? Sets.immutableEnumSet(SourceType.LOMBOK) : ImmutableSet.of();
     this.languageLevel =
-        getLanguageLevel(getValueFromKey(jsonObject, "LANGUAGE_LEVEL", String.class).orElse("11"));
+        getLanguageLevel(getValueFromKey(jsonObject, "LANGUAGE_LEVEL", String.class).orElse("17"));
     this.nonnullAnnotations =
         ImmutableSet.copyOf(
             getArrayValueFromKey(

--- a/annotator-core/src/main/java/edu/ucr/cs/riple/core/Config.java
+++ b/annotator-core/src/main/java/edu/ucr/cs/riple/core/Config.java
@@ -356,7 +356,7 @@ public class Config {
         new Option(
             "ll",
             "language-level",
-            false,
+            true,
             "Java language level to use when parsing code. Supported values are 11 and 17.  Defaults to 11.");
     languageLevel.setRequired(false);
     options.addOption(languageLevel);

--- a/annotator-core/src/main/java/edu/ucr/cs/riple/core/cache/downstream/DownstreamImpactCacheImpl.java
+++ b/annotator-core/src/main/java/edu/ucr/cs/riple/core/cache/downstream/DownstreamImpactCacheImpl.java
@@ -84,8 +84,8 @@ public class DownstreamImpactCacheImpl
       Context context, ModuleInfo moduleInfo) {
     ImmutableSet.Builder<Location> locationsToCache = ImmutableSet.builder();
     // Used to collect callers of each method.
-    MethodRegionRegistry methodRegionRegistry = new MethodRegionRegistry(moduleInfo);
-    FieldRegionRegistry fieldRegionRegistry = new FieldRegionRegistry(moduleInfo);
+    MethodRegionRegistry methodRegionRegistry = new MethodRegionRegistry(moduleInfo, context);
+    FieldRegionRegistry fieldRegionRegistry = new FieldRegionRegistry(moduleInfo, context);
     // Collect public methods with non-primitive return types.
     locationsToCache.addAll(
         context

--- a/annotator-core/src/main/java/edu/ucr/cs/riple/core/injectors/PhysicalInjector.java
+++ b/annotator-core/src/main/java/edu/ucr/cs/riple/core/injectors/PhysicalInjector.java
@@ -44,7 +44,7 @@ public class PhysicalInjector extends AnnotationInjector {
    */
   public PhysicalInjector(Context context) {
     super(context);
-    this.injector = new Injector();
+    this.injector = new Injector(context.config.languageLevel);
   }
 
   @Override

--- a/annotator-core/src/main/java/edu/ucr/cs/riple/core/module/ModuleInfo.java
+++ b/annotator-core/src/main/java/edu/ucr/cs/riple/core/module/ModuleInfo.java
@@ -88,7 +88,7 @@ public class ModuleInfo {
     context.checker.prepareConfigFilesForBuild(configurations);
     Utility.runScannerChecker(context, configurations, buildCommand);
     this.nonnullStore = new NonnullStore(configurations);
-    this.fieldRegistry = new FieldRegistry(configurations);
+    this.fieldRegistry = new FieldRegistry(configurations, context);
     this.methodRegistry = new MethodRegistry(context);
     this.regionRegistry = new CompoundRegionRegistry(this);
     ImmutableSet.Builder<AnnotationProcessorHandler> builder = new ImmutableSet.Builder<>();

--- a/annotator-core/src/main/java/edu/ucr/cs/riple/core/module/ModuleInfo.java
+++ b/annotator-core/src/main/java/edu/ucr/cs/riple/core/module/ModuleInfo.java
@@ -87,10 +87,10 @@ public class ModuleInfo {
     // Build with scanner checker activated to generate required files to create the moduleInfo.
     context.checker.prepareConfigFilesForBuild(configurations);
     Utility.runScannerChecker(context, configurations, buildCommand);
-    this.nonnullStore = new NonnullStore(configurations);
+    this.nonnullStore = new NonnullStore(configurations, context);
     this.fieldRegistry = new FieldRegistry(configurations, context);
     this.methodRegistry = new MethodRegistry(context);
-    this.regionRegistry = new CompoundRegionRegistry(this);
+    this.regionRegistry = new CompoundRegionRegistry(this, context);
     ImmutableSet.Builder<AnnotationProcessorHandler> builder = new ImmutableSet.Builder<>();
     if (context.config.generatedCodeDetectors.contains(SourceType.LOMBOK)) {
       builder.add(new LombokHandler(this));

--- a/annotator-core/src/main/java/edu/ucr/cs/riple/core/registries/Registry.java
+++ b/annotator-core/src/main/java/edu/ucr/cs/riple/core/registries/Registry.java
@@ -26,6 +26,7 @@ package edu.ucr.cs.riple.core.registries;
 
 import com.google.common.collect.ImmutableMultimap;
 import com.google.common.collect.ImmutableSet;
+import edu.ucr.cs.riple.core.Context;
 import java.io.BufferedReader;
 import java.io.IOException;
 import java.nio.charset.Charset;
@@ -54,14 +55,17 @@ public abstract class Registry<T> {
    */
   protected final ImmutableMultimap<Integer, T> contents;
 
+  protected final Context context;
+
   /**
    * Constructor for this container. Once this constructor is invoked, all data will be loaded from
    * the file.
    *
    * @param path Path to the file containing the data.
    */
-  public Registry(Path path) {
+  public Registry(Path path, Context context) {
     ImmutableMultimap.Builder<Integer, T> builder = ImmutableMultimap.builder();
+    this.context = context;
     setup();
     try {
       populateContent(path, builder);
@@ -77,8 +81,9 @@ public abstract class Registry<T> {
    *
    * @param paths Paths to all files containing data.
    */
-  public Registry(ImmutableSet<Path> paths) {
+  public Registry(ImmutableSet<Path> paths, Context context) {
     ImmutableMultimap.Builder<Integer, T> builder = ImmutableMultimap.builder();
+    this.context = context;
     setup();
     paths.forEach(
         path -> {

--- a/annotator-core/src/main/java/edu/ucr/cs/riple/core/registries/field/FieldInitializationStore.java
+++ b/annotator-core/src/main/java/edu/ucr/cs/riple/core/registries/field/FieldInitializationStore.java
@@ -60,7 +60,7 @@ public class FieldInitializationStore extends Registry<FieldInitializationNode> 
    * @param context Annotator context.
    */
   public FieldInitializationStore(Context context) {
-    super(context.targetConfiguration.dir.resolve(FILE_NAME));
+    super(context.targetConfiguration.dir.resolve(FILE_NAME), context);
   }
 
   /**

--- a/annotator-core/src/main/java/edu/ucr/cs/riple/core/registries/field/FieldRegistry.java
+++ b/annotator-core/src/main/java/edu/ucr/cs/riple/core/registries/field/FieldRegistry.java
@@ -63,8 +63,6 @@ public class FieldRegistry extends Registry<ClassFieldRecord> {
    * initialized at declaration.
    */
   private Multimap<String, String> uninitializedFields;
-
-  private final Context context;
   /**
    * Constructor for {@link FieldRegistry}.
    *
@@ -83,8 +81,8 @@ public class FieldRegistry extends Registry<ClassFieldRecord> {
     super(
         modules.stream()
             .map(info -> info.dir.resolve(Serializer.CLASS_RECORD_FILE_NAME))
-            .collect(ImmutableSet.toImmutableSet()));
-    this.context = context;
+            .collect(ImmutableSet.toImmutableSet()),
+        context);
   }
 
   @Override

--- a/annotator-core/src/main/java/edu/ucr/cs/riple/core/registries/field/FieldRegistry.java
+++ b/annotator-core/src/main/java/edu/ucr/cs/riple/core/registries/field/FieldRegistry.java
@@ -32,6 +32,7 @@ import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Multimap;
 import com.google.common.collect.MultimapBuilder;
 import com.google.common.collect.Sets;
+import edu.ucr.cs.riple.core.Context;
 import edu.ucr.cs.riple.core.module.ModuleConfiguration;
 import edu.ucr.cs.riple.core.registries.Registry;
 import edu.ucr.cs.riple.injector.Helper;
@@ -63,13 +64,14 @@ public class FieldRegistry extends Registry<ClassFieldRecord> {
    */
   private Multimap<String, String> uninitializedFields;
 
+  private final Context context;
   /**
    * Constructor for {@link FieldRegistry}.
    *
    * @param module Information of the target module.
    */
-  public FieldRegistry(ModuleConfiguration module) {
-    this(ImmutableSet.of(module));
+  public FieldRegistry(ModuleConfiguration module, Context context) {
+    this(ImmutableSet.of(module), context);
   }
 
   /**
@@ -77,11 +79,12 @@ public class FieldRegistry extends Registry<ClassFieldRecord> {
    *
    * @param modules Information of set of modules.
    */
-  public FieldRegistry(ImmutableSet<ModuleConfiguration> modules) {
+  public FieldRegistry(ImmutableSet<ModuleConfiguration> modules, Context context) {
     super(
         modules.stream()
             .map(info -> info.dir.resolve(Serializer.CLASS_RECORD_FILE_NAME))
             .collect(ImmutableSet.toImmutableSet()));
+    this.context = context;
   }
 
   @Override
@@ -97,7 +100,7 @@ public class FieldRegistry extends Registry<ClassFieldRecord> {
       String clazz = values[0];
       // Path to class.
       Path path = Helper.deserializePath(values[1]);
-      CompilationUnit tree = Injector.parse(path);
+      CompilationUnit tree = Injector.parse(path, context.config.languageLevel);
       if (tree == null) {
         return null;
       }

--- a/annotator-core/src/main/java/edu/ucr/cs/riple/core/registries/index/NonnullStore.java
+++ b/annotator-core/src/main/java/edu/ucr/cs/riple/core/registries/index/NonnullStore.java
@@ -25,6 +25,7 @@
 package edu.ucr.cs.riple.core.registries.index;
 
 import com.google.common.collect.ImmutableSet;
+import edu.ucr.cs.riple.core.Context;
 import edu.ucr.cs.riple.core.module.ModuleConfiguration;
 import edu.ucr.cs.riple.core.registries.Registry;
 import edu.ucr.cs.riple.injector.location.Location;
@@ -37,11 +38,12 @@ import edu.ucr.cs.riple.scanner.Serializer;
  */
 public class NonnullStore extends Registry<Location> {
 
-  public NonnullStore(ImmutableSet<ModuleConfiguration> modules) {
+  public NonnullStore(ImmutableSet<ModuleConfiguration> modules, Context context) {
     super(
         modules.stream()
             .map(moduleInfo -> moduleInfo.dir.resolve(Serializer.NON_NULL_ELEMENTS_FILE_NAME))
-            .collect(ImmutableSet.toImmutableSet()));
+            .collect(ImmutableSet.toImmutableSet()),
+        context);
   }
 
   @Override

--- a/annotator-core/src/main/java/edu/ucr/cs/riple/core/registries/method/MethodRegistry.java
+++ b/annotator-core/src/main/java/edu/ucr/cs/riple/core/registries/method/MethodRegistry.java
@@ -56,14 +56,15 @@ public class MethodRegistry extends Registry<MethodRecord> {
   private Set<String> declaredClasses;
 
   public MethodRegistry(Context context) {
-    this(ImmutableSet.of(context.targetConfiguration));
+    this(ImmutableSet.of(context.targetConfiguration), context);
   }
 
-  public MethodRegistry(ImmutableSet<ModuleConfiguration> modules) {
+  public MethodRegistry(ImmutableSet<ModuleConfiguration> modules, Context context) {
     super(
         modules.stream()
             .map(moduleInfo -> moduleInfo.dir.resolve(Serializer.METHOD_RECORD_FILE_NAME))
-            .collect(ImmutableSet.toImmutableSet()));
+            .collect(ImmutableSet.toImmutableSet()),
+        context);
   }
 
   @Override

--- a/annotator-core/src/main/java/edu/ucr/cs/riple/core/registries/region/CompoundRegionRegistry.java
+++ b/annotator-core/src/main/java/edu/ucr/cs/riple/core/registries/region/CompoundRegionRegistry.java
@@ -25,6 +25,7 @@
 package edu.ucr.cs.riple.core.registries.region;
 
 import com.google.common.collect.ImmutableSet;
+import edu.ucr.cs.riple.core.Context;
 import edu.ucr.cs.riple.core.module.ModuleInfo;
 import edu.ucr.cs.riple.core.registries.region.generatedcode.AnnotationProcessorHandler;
 import edu.ucr.cs.riple.injector.location.Location;
@@ -46,12 +47,12 @@ public class CompoundRegionRegistry implements RegionRegistry {
    */
   private final MethodRegionRegistry methodRegionRegistry;
 
-  public CompoundRegionRegistry(ModuleInfo moduleInfo) {
+  public CompoundRegionRegistry(ModuleInfo moduleInfo, Context context) {
     this.moduleInfo = moduleInfo;
-    this.methodRegionRegistry = new MethodRegionRegistry(moduleInfo);
+    this.methodRegionRegistry = new MethodRegionRegistry(moduleInfo, context);
     this.registries =
         ImmutableSet.of(
-            new FieldRegionRegistry(moduleInfo),
+            new FieldRegionRegistry(moduleInfo, context),
             methodRegionRegistry,
             new ParameterRegionRegistry(moduleInfo, methodRegionRegistry));
   }

--- a/annotator-core/src/main/java/edu/ucr/cs/riple/core/registries/region/FieldRegionRegistry.java
+++ b/annotator-core/src/main/java/edu/ucr/cs/riple/core/registries/region/FieldRegionRegistry.java
@@ -25,6 +25,7 @@
 package edu.ucr.cs.riple.core.registries.region;
 
 import com.google.common.collect.ImmutableSet;
+import edu.ucr.cs.riple.core.Context;
 import edu.ucr.cs.riple.core.module.ModuleInfo;
 import edu.ucr.cs.riple.core.registries.Registry;
 import edu.ucr.cs.riple.core.util.Utility;
@@ -42,13 +43,14 @@ public class FieldRegionRegistry extends Registry<RegionRecord> implements Regio
   /** ModuleInfo of the module which usages of fields are stored. */
   private final ModuleInfo moduleInfo;
 
-  public FieldRegionRegistry(ModuleInfo moduleInfo) {
+  public FieldRegionRegistry(ModuleInfo moduleInfo, Context context) {
     super(
         moduleInfo.getModuleConfigurations().stream()
             .map(
                 configuration ->
                     configuration.dir.resolve(Serializer.FIELD_IMPACTED_REGION_FILE_NAME))
-            .collect(ImmutableSet.toImmutableSet()));
+            .collect(ImmutableSet.toImmutableSet()),
+        context);
     this.moduleInfo = moduleInfo;
   }
 

--- a/annotator-core/src/main/java/edu/ucr/cs/riple/core/registries/region/MethodRegionRegistry.java
+++ b/annotator-core/src/main/java/edu/ucr/cs/riple/core/registries/region/MethodRegionRegistry.java
@@ -25,6 +25,7 @@
 package edu.ucr.cs.riple.core.registries.region;
 
 import com.google.common.collect.ImmutableSet;
+import edu.ucr.cs.riple.core.Context;
 import edu.ucr.cs.riple.core.module.ModuleInfo;
 import edu.ucr.cs.riple.core.registries.Registry;
 import edu.ucr.cs.riple.core.registries.method.MethodRecord;
@@ -42,11 +43,12 @@ public class MethodRegionRegistry extends Registry<RegionRecord> implements Regi
   /** ModuleInfo of the module which usage of methods are stored. */
   private final ModuleInfo moduleInfo;
 
-  public MethodRegionRegistry(ModuleInfo moduleInfo) {
+  public MethodRegionRegistry(ModuleInfo moduleInfo, Context context) {
     super(
         moduleInfo.getModuleConfigurations().stream()
             .map(info -> info.dir.resolve(Serializer.METHOD_IMPACTED_REGION_FILE_NAME))
-            .collect(ImmutableSet.toImmutableSet()));
+            .collect(ImmutableSet.toImmutableSet()),
+        context);
     this.moduleInfo = moduleInfo;
   }
 

--- a/annotator-core/src/test/java/edu/ucr/cs/riple/core/Java17Test.java
+++ b/annotator-core/src/test/java/edu/ucr/cs/riple/core/Java17Test.java
@@ -24,6 +24,7 @@
 
 package edu.ucr.cs.riple.core;
 
+import com.github.javaparser.ParserConfiguration;
 import edu.ucr.cs.riple.core.tools.TReport;
 import edu.ucr.cs.riple.injector.location.OnField;
 import edu.ucr.cs.riple.injector.location.OnMethod;
@@ -56,6 +57,7 @@ public class Java17Test extends AnnotatorBaseCoreTest {
             "}")
         .withExpectedReports(
             new TReport(new OnField("Main.java", "test.Main", Set.of("f1", "f2", "f3", "f4")), -4))
+        .withLanguageLevel(ParserConfiguration.LanguageLevel.JAVA_17)
         .start();
   }
 
@@ -74,6 +76,7 @@ public class Java17Test extends AnnotatorBaseCoreTest {
         .withExpectedReports(
             new TReport(new OnMethod("A.java", "test.A", "create(java.lang.String)"), -1))
         .toDepth(5)
+        .withLanguageLevel(ParserConfiguration.LanguageLevel.JAVA_17)
         .start();
   }
 }

--- a/annotator-core/src/test/java/edu/ucr/cs/riple/core/tools/CoreTestHelper.java
+++ b/annotator-core/src/test/java/edu/ucr/cs/riple/core/tools/CoreTestHelper.java
@@ -319,7 +319,7 @@ public class CoreTestHelper {
       walk.filter(path -> path.toFile().isFile() && path.toFile().getName().endsWith(".java"))
           .forEach(
               path -> {
-                if (!Helper.srcIsUnderClassClassPath(path, "test")) {
+                if (!Helper.srcIsUnderClassClassPath(path, "test", config.languageLevel)) {
                   throw new IllegalArgumentException(
                       "Source files must have package declaration starting with \"test\": " + path);
                 }

--- a/annotator-core/src/test/java/edu/ucr/cs/riple/core/tools/CoreTestHelper.java
+++ b/annotator-core/src/test/java/edu/ucr/cs/riple/core/tools/CoreTestHelper.java
@@ -328,12 +328,7 @@ public class CoreTestHelper {
       walk.filter(path -> path.toFile().isFile() && path.toFile().getName().endsWith(".java"))
           .forEach(
               path -> {
-                if (!Helper.srcIsUnderClassClassPath(
-                    path,
-                    "test",
-                    config != null
-                        ? config.languageLevel
-                        : ParserConfiguration.LanguageLevel.JAVA_11)) {
+                if (!Helper.srcIsUnderClassClassPath(path, "test", languageLevel)) {
                   throw new IllegalArgumentException(
                       "Source files must have package declaration starting with \"test\": " + path);
                 }

--- a/annotator-core/src/test/java/edu/ucr/cs/riple/core/tools/CoreTestHelper.java
+++ b/annotator-core/src/test/java/edu/ucr/cs/riple/core/tools/CoreTestHelper.java
@@ -90,11 +90,14 @@ public class CoreTestHelper {
   /** Annotator log instance after the test execution. */
   private Log log;
 
+  private ParserConfiguration.LanguageLevel languageLevel;
+
   public CoreTestHelper(Path projectPath, Path outDirPath) {
     this.projectPath = projectPath;
     this.outDirPath = outDirPath;
     this.expectedReports = new HashSet<>();
     this.projectBuilder = new ProjectBuilder(this, projectPath);
+    this.languageLevel = ParserConfiguration.LanguageLevel.JAVA_11;
   }
 
   public Module onTarget() {
@@ -213,6 +216,11 @@ public class CoreTestHelper {
    */
   public CoreTestHelper checkExpectedOutput(String expectedOutputPath) {
     this.expectedOutputPath = Utility.getPathOfResource(expectedOutputPath);
+    return this;
+  }
+
+  public CoreTestHelper withLanguageLevel(ParserConfiguration.LanguageLevel languageLevel) {
+    this.languageLevel = languageLevel;
     return this;
   }
 
@@ -408,6 +416,7 @@ public class CoreTestHelper {
     builder.useCacheImpact = true;
     builder.sourceTypes.add(SourceType.LOMBOK);
     builder.cache = true;
+    builder.languageLevel = languageLevel;
     builder.useCacheImpact = !getEnvironmentVariable("ANNOTATOR_TEST_DISABLE_CACHING");
     builder.useParallelProcessor =
         !getEnvironmentVariable("ANNOTATOR_TEST_DISABLE_PARALLEL_PROCESSING");

--- a/annotator-core/src/test/java/edu/ucr/cs/riple/core/tools/CoreTestHelper.java
+++ b/annotator-core/src/test/java/edu/ucr/cs/riple/core/tools/CoreTestHelper.java
@@ -97,7 +97,7 @@ public class CoreTestHelper {
     this.outDirPath = outDirPath;
     this.expectedReports = new HashSet<>();
     this.projectBuilder = new ProjectBuilder(this, projectPath);
-    this.languageLevel = ParserConfiguration.LanguageLevel.JAVA_11;
+    this.languageLevel = ParserConfiguration.LanguageLevel.JAVA_17;
   }
 
   public Module onTarget() {

--- a/annotator-core/src/test/java/edu/ucr/cs/riple/core/tools/CoreTestHelper.java
+++ b/annotator-core/src/test/java/edu/ucr/cs/riple/core/tools/CoreTestHelper.java
@@ -26,6 +26,7 @@ package edu.ucr.cs.riple.core.tools;
 
 import static org.junit.Assert.fail;
 
+import com.github.javaparser.ParserConfiguration;
 import edu.ucr.cs.riple.core.AnalysisMode;
 import edu.ucr.cs.riple.core.Annotator;
 import edu.ucr.cs.riple.core.Config;
@@ -319,7 +320,12 @@ public class CoreTestHelper {
       walk.filter(path -> path.toFile().isFile() && path.toFile().getName().endsWith(".java"))
           .forEach(
               path -> {
-                if (!Helper.srcIsUnderClassClassPath(path, "test", config.languageLevel)) {
+                if (!Helper.srcIsUnderClassClassPath(
+                    path,
+                    "test",
+                    config != null
+                        ? config.languageLevel
+                        : ParserConfiguration.LanguageLevel.JAVA_11)) {
                   throw new IllegalArgumentException(
                       "Source files must have package declaration starting with \"test\": " + path);
                 }

--- a/gradle.properties
+++ b/gradle.properties
@@ -22,7 +22,7 @@
 
 
 GROUP=edu.ucr.cs.riple.annotator
-VERSION_NAME=1.3.13
+VERSION_NAME=1.3.14-SNAPSHOT
 
 POM_NAME=Annotator
 POM_DESCRIPTION=A tool that automatically fixes source code to pass NullAway checks.

--- a/injector/src/main/java/edu/ucr/cs/riple/injector/Helper.java
+++ b/injector/src/main/java/edu/ucr/cs/riple/injector/Helper.java
@@ -549,7 +549,8 @@ public class Helper {
    * @param rootPackage Root package simple name.
    * @return true if src has a package declaration and starts with root.
    */
-  public static boolean srcIsUnderClassClassPath(Path path, String rootPackage, ParserConfiguration.LanguageLevel languageLevel) {
+  public static boolean srcIsUnderClassClassPath(
+      Path path, String rootPackage, ParserConfiguration.LanguageLevel languageLevel) {
     CompilationUnit cu = Injector.parse(path, languageLevel);
     if (cu == null) {
       return false;

--- a/injector/src/main/java/edu/ucr/cs/riple/injector/Helper.java
+++ b/injector/src/main/java/edu/ucr/cs/riple/injector/Helper.java
@@ -22,6 +22,7 @@
 
 package edu.ucr.cs.riple.injector;
 
+import com.github.javaparser.ParserConfiguration;
 import com.github.javaparser.ast.CompilationUnit;
 import com.github.javaparser.ast.Node;
 import com.github.javaparser.ast.NodeList;
@@ -548,8 +549,8 @@ public class Helper {
    * @param rootPackage Root package simple name.
    * @return true if src has a package declaration and starts with root.
    */
-  public static boolean srcIsUnderClassClassPath(Path path, String rootPackage) {
-    CompilationUnit cu = Injector.parse(path);
+  public static boolean srcIsUnderClassClassPath(Path path, String rootPackage, ParserConfiguration.LanguageLevel languageLevel) {
+    CompilationUnit cu = Injector.parse(path, languageLevel);
     if (cu == null) {
       return false;
     }

--- a/injector/src/main/java/edu/ucr/cs/riple/injector/Injector.java
+++ b/injector/src/main/java/edu/ucr/cs/riple/injector/Injector.java
@@ -47,6 +47,16 @@ import javax.annotation.Nullable;
 /** Injector main class which can add / remove annotations. */
 public class Injector {
 
+  private final ParserConfiguration.LanguageLevel languageLevel;
+
+  public Injector() {
+    this(ParserConfiguration.LanguageLevel.JAVA_11);
+  }
+
+  public Injector(ParserConfiguration.LanguageLevel languageLevel) {
+    this.languageLevel = languageLevel;
+  }
+
   /**
    * Starts applying the requested changes.
    *
@@ -61,7 +71,7 @@ public class Injector {
     Set<FileOffsetStore> offsets = new HashSet<>();
     map.forEach(
         (path, changeList) -> {
-          CompilationUnit tree = parse(path);
+          CompilationUnit tree = parse(path, languageLevel);
           if (tree == null) {
             return;
           }
@@ -147,7 +157,7 @@ public class Injector {
    * @return Compilation unit tree, if the file does not exist, returns null.
    */
   @Nullable
-  public static CompilationUnit parse(@Nullable Path path) {
+  public static CompilationUnit parse(@Nullable Path path, ParserConfiguration.LanguageLevel level) {
     if (path == null) {
       // Annotator is correctly receiving null as argument for fixes suggested on third party
       // libraries. And NullAway is correctly serializing fixes with null paths. Please note that we
@@ -156,8 +166,7 @@ public class Injector {
       return null;
     }
     ParserConfiguration parserConfiguration = new ParserConfiguration();
-    // Set parser configuration to Java 17.
-    parserConfiguration.setLanguageLevel(ParserConfiguration.LanguageLevel.JAVA_17);
+    parserConfiguration.setLanguageLevel(level);
     StaticJavaParser.setConfiguration(parserConfiguration);
     try {
       return StaticJavaParser.parse(path);

--- a/injector/src/main/java/edu/ucr/cs/riple/injector/Injector.java
+++ b/injector/src/main/java/edu/ucr/cs/riple/injector/Injector.java
@@ -157,7 +157,8 @@ public class Injector {
    * @return Compilation unit tree, if the file does not exist, returns null.
    */
   @Nullable
-  public static CompilationUnit parse(@Nullable Path path, ParserConfiguration.LanguageLevel level) {
+  public static CompilationUnit parse(
+      @Nullable Path path, ParserConfiguration.LanguageLevel level) {
     if (path == null) {
       // Annotator is correctly receiving null as argument for fixes suggested on third party
       // libraries. And NullAway is correctly serializing fixes with null paths. Please note that we


### PR DESCRIPTION
Needed to work around https://github.com/javaparser/javaparser/issues/4041.  Users impacted by that issue can set the language level to 11, assuming they are not using language constructs introduced after that version.