### PR TITLE
Upgrade javaparser to 3.26.0

### DIFF
--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -35,7 +35,7 @@ def versions = [
         errorProne             : defaultErrorProneVersion,
         errorProneApi          : project.hasProperty("epApiVersion") ? epApiVersion : oldestErrorProneApi,
         autoService            : "1.0-rc7",
-        javaparser             : "3.25.7",
+        javaparser             : "3.26.0",
         json                   : "1.1.1",
         guava                  : "31.0.1-jre",
         cli                    : "1.5.0",


### PR DESCRIPTION
Upgrades javaparser to version `3.26.0`. Fixes the issue with `sealed`/`permits` used as variables.