### PR TITLE
clean up fixIsSource flag from fix class

### DIFF
--- a/annotator-core/src/main/java/edu/ucr/cs/riple/core/cache/downstream/DownstreamImpactCacheImpl.java
+++ b/annotator-core/src/main/java/edu/ucr/cs/riple/core/cache/downstream/DownstreamImpactCacheImpl.java
@@ -123,9 +123,7 @@ public class DownstreamImpactCacheImpl
             .map(
                 location ->
                     new Fix(
-                        new AddMarkerAnnotation(location, context.config.nullableAnnot),
-                        "null",
-                        false))
+                        new AddMarkerAnnotation(location, context.config.nullableAnnot), "null"))
             .collect(ImmutableSet.toImmutableSet());
     DownstreamImpactEvaluator evaluator = new DownstreamImpactEvaluator(supplier);
     ImmutableSet<Report> reports = evaluator.evaluate(fixes);

--- a/annotator-core/src/main/java/edu/ucr/cs/riple/core/checkers/nullaway/NullAway.java
+++ b/annotator-core/src/main/java/edu/ucr/cs/riple/core/checkers/nullaway/NullAway.java
@@ -130,8 +130,7 @@ public class NullAway extends CheckerBaseClass<NullAwayError> {
     Fix resolvingFix =
         nonnullTarget == null
             ? null
-            : new Fix(
-                new AddMarkerAnnotation(nonnullTarget, config.nullableAnnot), errorType, true);
+            : new Fix(new AddMarkerAnnotation(nonnullTarget, config.nullableAnnot), errorType);
     return createError(
         errorType,
         errorMessage,
@@ -201,8 +200,7 @@ public class NullAway extends CheckerBaseClass<NullAwayError> {
               return new Fix(
                   new AddMarkerAnnotation(
                       extendVariableList(locationOnField, module), config.nullableAnnot),
-                  NullAwayError.METHOD_INITIALIZER_ERROR,
-                  true);
+                  NullAwayError.METHOD_INITIALIZER_ERROR);
             })
         .filter(Objects::nonNull)
         .collect(ImmutableSet.toImmutableSet());

--- a/annotator-core/src/main/java/edu/ucr/cs/riple/core/evaluators/graph/Node.java
+++ b/annotator-core/src/main/java/edu/ucr/cs/riple/core/evaluators/graph/Node.java
@@ -186,7 +186,6 @@ public class Node {
   public void mergeTriggered() {
     this.tree.addAll(Error.getResolvingFixesOfErrors(this.triggeredErrors));
     this.tree.addAll(triggeredFixesFromDownstreamErrors);
-    this.tree.forEach(fix -> fix.fixSourceIsInTarget = true);
   }
 
   @Override

--- a/annotator-core/src/main/java/edu/ucr/cs/riple/core/evaluators/graph/processors/AbstractConflictGraphProcessor.java
+++ b/annotator-core/src/main/java/edu/ucr/cs/riple/core/evaluators/graph/processors/AbstractConflictGraphProcessor.java
@@ -81,8 +81,7 @@ public abstract class AbstractConflictGraphProcessor implements ConflictGraphPro
                 new Fix(
                     new AddMarkerAnnotation(
                         error.toResolvingLocation(), context.config.nullableAnnot),
-                    "PASSING_NULLABLE",
-                    false))
+                    "PASSING_NULLABLE"))
         .collect(Collectors.toSet());
   }
 }

--- a/annotator-core/src/main/java/edu/ucr/cs/riple/core/registries/index/Error.java
+++ b/annotator-core/src/main/java/edu/ucr/cs/riple/core/registries/index/Error.java
@@ -223,9 +223,7 @@ public abstract class Error {
     for (Fix key : fixReasonsMap.keySet()) {
       // To avoid mutating fixes stored in the given collection, we create new instances.
       // which contain the full set of reasons.
-      builder.add(
-          new Fix(
-              key.change, ImmutableSet.copyOf(fixReasonsMap.get(key)), key.fixSourceIsInTarget));
+      builder.add(new Fix(key.change, ImmutableSet.copyOf(fixReasonsMap.get(key))));
     }
     return builder.build();
   }

--- a/annotator-core/src/main/java/edu/ucr/cs/riple/core/registries/index/Fix.java
+++ b/annotator-core/src/main/java/edu/ucr/cs/riple/core/registries/index/Fix.java
@@ -48,20 +48,13 @@ public class Fix {
   /** Reasons this fix is suggested by NullAway in string. */
   public final ImmutableSet<String> reasons;
 
-  /**
-   * If true, the fix is suggested due to an error in the target module, false if the fix is
-   * suggested due to error in downstream dependencies.
-   */
-  public boolean fixSourceIsInTarget;
-
-  public Fix(AddAnnotation change, String reason, boolean fixSourceIsInTarget) {
-    this(change, ImmutableSet.of(reason), fixSourceIsInTarget);
+  public Fix(AddAnnotation change, String reason) {
+    this(change, ImmutableSet.of(reason));
   }
 
-  public Fix(AddAnnotation change, ImmutableSet<String> reasons, boolean fixSourceIsInTarget) {
+  public Fix(AddAnnotation change, ImmutableSet<String> reasons) {
     this.change = change;
     this.reasons = reasons;
-    this.fixSourceIsInTarget = fixSourceIsInTarget;
   }
 
   /**

--- a/annotator-core/src/main/java/edu/ucr/cs/riple/core/registries/region/generatedcode/LombokHandler.java
+++ b/annotator-core/src/main/java/edu/ucr/cs/riple/core/registries/region/generatedcode/LombokHandler.java
@@ -120,8 +120,7 @@ public class LombokHandler implements AnnotationProcessorHandler {
                                 new Fix(
                                     new AddMarkerAnnotation(
                                         getterMethod.location, change.getAnnotationName().fullName),
-                                    fix.reasons,
-                                    fix.fixSourceIsInTarget));
+                                    fix.reasons));
                           }
                         })));
     return builder.build();

--- a/annotator-core/src/test/java/edu/ucr/cs/riple/core/tools/TFix.java
+++ b/annotator-core/src/test/java/edu/ucr/cs/riple/core/tools/TFix.java
@@ -36,6 +36,6 @@ import edu.ucr.cs.riple.injector.location.Location;
 public class TFix extends Fix {
 
   public TFix(Location location) {
-    super(new DefaultAnnotation(location), ImmutableSet.of(), true);
+    super(new DefaultAnnotation(location), ImmutableSet.of());
   }
 }

--- a/annotator-core/src/test/java/edu/ucr/cs/riple/core/tools/TReport.java
+++ b/annotator-core/src/test/java/edu/ucr/cs/riple/core/tools/TReport.java
@@ -50,8 +50,7 @@ public class TReport extends Report {
 
   public TReport(Location root, int effect, Tag tag) {
     super(
-        new Fix(
-            new AddMarkerAnnotation(root, "javax.annotation.Nullable"), ImmutableSet.of(), true),
+        new Fix(new AddMarkerAnnotation(root, "javax.annotation.Nullable"), ImmutableSet.of()),
         effect);
     this.expectedValue = effect;
     if (tag != null) {


### PR DESCRIPTION
This PR removes the unused flag `fixIsSource` which indicates if the fix is suggested from an error in the source code of target or downstream dependency. This flag is not used in the latest logic anymore and is redundant. This PR removes this flag from the fix class declaration.