### PR TITLE
Move createErrorToSubclass method to subclass

### DIFF
--- a/annotator-core/src/main/java/edu/ucr/cs/riple/core/checkers/Checker.java
+++ b/annotator-core/src/main/java/edu/ucr/cs/riple/core/checkers/Checker.java
@@ -64,25 +64,6 @@ public interface Checker<T extends Error> {
   void preprocess(AnnotationInjector injector);
 
   /**
-   * Creates an {@link Error} instance from the given parameters.
-   *
-   * @param errorType Error type.
-   * @param errorMessage Error message.
-   * @param region Region where the error is reported,
-   * @param offset offset of program point in original version where error is reported.
-   * @param resolvingFixes Set of fixes that resolve the error.
-   * @param module Module where the error is reported.
-   * @return The corresponding error.
-   */
-  T createError(
-      String errorType,
-      String errorMessage,
-      Region region,
-      int offset,
-      ImmutableSet<Fix> resolvingFixes,
-      ModuleInfo module);
-
-  /**
    * Verifies that the checker representation in Annotator is compatible with the actual running
    * checker on the target module.
    */

--- a/annotator-core/src/main/java/edu/ucr/cs/riple/core/checkers/Checker.java
+++ b/annotator-core/src/main/java/edu/ucr/cs/riple/core/checkers/Checker.java
@@ -29,8 +29,6 @@ import edu.ucr.cs.riple.core.injectors.AnnotationInjector;
 import edu.ucr.cs.riple.core.module.ModuleConfiguration;
 import edu.ucr.cs.riple.core.module.ModuleInfo;
 import edu.ucr.cs.riple.core.registries.index.Error;
-import edu.ucr.cs.riple.core.registries.index.Fix;
-import edu.ucr.cs.riple.core.registries.region.Region;
 import java.util.Set;
 
 /**

--- a/annotator-core/src/main/java/edu/ucr/cs/riple/core/checkers/nullaway/NullAway.java
+++ b/annotator-core/src/main/java/edu/ucr/cs/riple/core/checkers/nullaway/NullAway.java
@@ -371,6 +371,19 @@ public class NullAway extends CheckerBaseClass<NullAwayError> {
     injector.injectAnnotations(initializers);
   }
 
+  /**
+   * Creates a {@link NullAwayError} instance using the provided arguments. It also removes
+   * annotation change requests that are on an element with explict nonnull annotation.
+   *
+   * @param errorType Error Type from NullAway.
+   * @param errorMessage Error Message from NullAway.
+   * @param region Region where the error is reported.
+   * @param offset Offset of program point in the source file where the error is reported.
+   * @param resolvingFixes Resolving fixes that can fix the error if all applied to source code.
+   * @param module Module where this error is reported.
+   * @return Creates and returns the corresponding {@link NullAwayError} instance using the provided
+   *     information.
+   */
   private NullAwayError createError(
       String errorType,
       String errorMessage,

--- a/annotator-core/src/main/java/edu/ucr/cs/riple/core/checkers/nullaway/NullAway.java
+++ b/annotator-core/src/main/java/edu/ucr/cs/riple/core/checkers/nullaway/NullAway.java
@@ -371,8 +371,7 @@ public class NullAway extends CheckerBaseClass<NullAwayError> {
     injector.injectAnnotations(initializers);
   }
 
-  @Override
-  public NullAwayError createError(
+  private NullAwayError createError(
       String errorType,
       String errorMessage,
       Region region,


### PR DESCRIPTION
This PR is a cleanup that is required before the upcoming major PR that adds support for taint checker inference.

Method `checker#createErrorToSubclass` is only used in subclass instance. This PR moves the declaration to the subclass that uses this method and removes it from the super class.