### PR TITLE
Bug fix in Injector Helper API for field declaration type computation

### DIFF
--- a/injector/src/main/java/edu/ucr/cs/riple/injector/Helper.java
+++ b/injector/src/main/java/edu/ucr/cs/riple/injector/Helper.java
@@ -393,7 +393,9 @@ public class Helper {
       return ((MethodDeclaration) node).getType();
     }
     if (node instanceof FieldDeclaration) {
-      return ((FieldDeclaration) node).getElementType();
+      FieldDeclaration fd = (FieldDeclaration) node;
+      Preconditions.checkArgument(!fd.getVariables().isEmpty());
+      return fd.getVariables().get(0).getType();
     }
     if (node instanceof VariableDeclarationExpr) {
       NodeList<VariableDeclarator> decls = ((VariableDeclarationExpr) node).getVariables();


### PR DESCRIPTION
This PR resolves a bug in Injector utility methods. The type for field declaration were not computed correctly  and the raw type was returned with can loose some important information. This PR fixes that.