### PR TITLE
Split utility methods into two separate util class

### DIFF
--- a/annotator-core/src/main/java/edu/ucr/cs/riple/core/checkers/nullaway/NullAway.java
+++ b/annotator-core/src/main/java/edu/ucr/cs/riple/core/checkers/nullaway/NullAway.java
@@ -36,7 +36,7 @@ import edu.ucr.cs.riple.core.registries.index.Error;
 import edu.ucr.cs.riple.core.registries.index.Fix;
 import edu.ucr.cs.riple.core.registries.region.Region;
 import edu.ucr.cs.riple.core.util.Utility;
-import edu.ucr.cs.riple.injector.Helper;
+import edu.ucr.cs.riple.injector.Printer;
 import edu.ucr.cs.riple.injector.changes.AddAnnotation;
 import edu.ucr.cs.riple.injector.changes.AddMarkerAnnotation;
 import edu.ucr.cs.riple.injector.changes.AddSingleElementAnnotation;
@@ -109,7 +109,7 @@ public class NullAway extends CheckerBaseClass<NullAwayError> {
         "Expected 12 values to create Error instance in NullAway serialization version 2 but found: "
             + values.length);
     int offset = Integer.parseInt(values[4]);
-    Path path = Helper.deserializePath(values[5]);
+    Path path = Printer.deserializePath(values[5]);
     String errorMessage = values[1];
     String errorType = values[0];
     Region region = new Region(values[2], values[3]);

--- a/annotator-core/src/main/java/edu/ucr/cs/riple/core/registries/field/FieldRegistry.java
+++ b/annotator-core/src/main/java/edu/ucr/cs/riple/core/registries/field/FieldRegistry.java
@@ -36,12 +36,13 @@ import com.google.common.collect.Sets;
 import edu.ucr.cs.riple.core.Context;
 import edu.ucr.cs.riple.core.module.ModuleConfiguration;
 import edu.ucr.cs.riple.core.registries.Registry;
-import edu.ucr.cs.riple.injector.Helper;
 import edu.ucr.cs.riple.injector.Injector;
+import edu.ucr.cs.riple.injector.Printer;
 import edu.ucr.cs.riple.injector.exceptions.TargetClassNotFound;
 import edu.ucr.cs.riple.injector.location.Location;
 import edu.ucr.cs.riple.injector.location.OnClass;
 import edu.ucr.cs.riple.injector.location.OnField;
+import edu.ucr.cs.riple.injector.util.ASTUtils;
 import edu.ucr.cs.riple.scanner.Serializer;
 import java.nio.file.Path;
 import java.util.Collections;
@@ -106,7 +107,7 @@ public class FieldRegistry extends Registry<ClassFieldRecord> {
         // This optimization is according to the assumption that Scanner
         // visits all classes within a single compilation unit tree consecutively.
         // Path to class.
-        Path path = Helper.deserializePath(values[1]);
+        Path path = Printer.deserializePath(values[1]);
         CompilationUnit tree;
         if (lastParsedSourceFile.a != null && lastParsedSourceFile.a.equals(path)) {
           // Already visited.
@@ -123,7 +124,7 @@ public class FieldRegistry extends Registry<ClassFieldRecord> {
         // Class flat name.
         String clazz = values[0];
         try {
-          members = Helper.getTypeDeclarationMembersByFlatName(tree, clazz);
+          members = ASTUtils.getTypeDeclarationMembersByFlatName(tree, clazz);
         } catch (TargetClassNotFound notFound) {
           System.err.println(notFound.getMessage());
           return null;

--- a/annotator-core/src/main/java/edu/ucr/cs/riple/core/registries/method/MethodRegistry.java
+++ b/annotator-core/src/main/java/edu/ucr/cs/riple/core/registries/method/MethodRegistry.java
@@ -32,9 +32,10 @@ import com.google.common.collect.MultimapBuilder;
 import edu.ucr.cs.riple.core.Context;
 import edu.ucr.cs.riple.core.module.ModuleConfiguration;
 import edu.ucr.cs.riple.core.registries.Registry;
-import edu.ucr.cs.riple.injector.Helper;
+import edu.ucr.cs.riple.injector.Printer;
 import edu.ucr.cs.riple.injector.location.Location;
 import edu.ucr.cs.riple.injector.location.OnMethod;
+import edu.ucr.cs.riple.injector.util.ASTUtils;
 import edu.ucr.cs.riple.scanner.Serializer;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -93,11 +94,11 @@ public class MethodRegistry extends Registry<MethodRecord> {
       }
       // Fill nodes information.
       Integer parentId = Integer.parseInt(values[3]);
-      OnMethod location = new OnMethod(Helper.deserializePath(values[8]), values[1], values[2]);
+      OnMethod location = new OnMethod(Printer.deserializePath(values[8]), values[1], values[2]);
       boolean isConstructor =
-          Helper.extractCallableName(location.method).equals(Helper.simpleName(location.clazz));
+          ASTUtils.extractCallableName(location.method).equals(ASTUtils.simpleName(location.clazz));
       node.fillInformation(
-          new OnMethod(Helper.deserializePath(values[8]), values[1], values[2]),
+          new OnMethod(Printer.deserializePath(values[8]), values[1], values[2]),
           parentId,
           ImmutableSet.copyOf(values[5].split(ANNOTATION_DELIMITER)),
           values[6],

--- a/annotator-core/src/main/java/edu/ucr/cs/riple/core/registries/region/Region.java
+++ b/annotator-core/src/main/java/edu/ucr/cs/riple/core/registries/region/Region.java
@@ -24,8 +24,8 @@
 
 package edu.ucr.cs.riple.core.registries.region;
 
-import edu.ucr.cs.riple.injector.Helper;
 import edu.ucr.cs.riple.injector.location.OnClass;
+import edu.ucr.cs.riple.injector.util.ASTUtils;
 import edu.ucr.cs.riple.scanner.generatedcode.SourceType;
 import java.util.Objects;
 
@@ -82,7 +82,7 @@ public class Region {
       return Type.INIT_BLOCK;
     }
     if (regionMember.contains("(")) {
-      return Helper.extractCallableName(regionMember).equals(Helper.simpleName(regionClass))
+      return ASTUtils.extractCallableName(regionMember).equals(ASTUtils.simpleName(regionClass))
           ? Type.CONSTRUCTOR
           : Type.METHOD;
     }

--- a/injector/src/main/java/edu/ucr/cs/riple/injector/Injector.java
+++ b/injector/src/main/java/edu/ucr/cs/riple/injector/Injector.java
@@ -41,6 +41,7 @@ import edu.ucr.cs.riple.injector.exceptions.ParseException;
 import edu.ucr.cs.riple.injector.location.Location;
 import edu.ucr.cs.riple.injector.modifications.Modification;
 import edu.ucr.cs.riple.injector.offsets.FileOffsetStore;
+import edu.ucr.cs.riple.injector.util.ASTUtils;
 import java.io.IOException;
 import java.nio.file.NoSuchFileException;
 import java.nio.file.Path;
@@ -95,7 +96,7 @@ public class Injector {
                 modifications.add(modification);
                 if (change instanceof AddAnnotation) {
                   String annotationFullName = ((AnnotationChange) change).annotationName.fullName;
-                  if (Helper.getPackageName(annotationFullName) != null) {
+                  if (ASTUtils.getPackageName(annotationFullName) != null) {
                     ImportDeclaration importDeclaration =
                         StaticJavaParser.parseImport("import " + annotationFullName + ";");
                     if (treeRequiresImportDeclaration(
@@ -140,7 +141,8 @@ public class Injector {
     return tree.getImports().stream()
         .noneMatch(
             impDecl ->
-                Helper.simpleName(impDecl.getNameAsString()).equals(Helper.simpleName(annotation)));
+                ASTUtils.simpleName(impDecl.getNameAsString())
+                    .equals(ASTUtils.simpleName(annotation)));
   }
 
   /**

--- a/injector/src/main/java/edu/ucr/cs/riple/injector/Printer.java
+++ b/injector/src/main/java/edu/ucr/cs/riple/injector/Printer.java
@@ -33,6 +33,7 @@ import java.io.IOException;
 import java.nio.charset.Charset;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.nio.file.Paths;
 import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
@@ -176,5 +177,32 @@ public class Printer {
       throw new RuntimeException(e);
     }
     return offsetStore;
+  }
+
+  /**
+   * Deserializes a Path instance from a string.
+   *
+   * @param serializedPath Serialized path to file.
+   * @return The modified Path.
+   */
+  public static Path deserializePath(String serializedPath) {
+    final String jarPrefix = "jar:";
+    final String filePrefix = "file://";
+    String path = serializedPath;
+    if (serializedPath.startsWith(jarPrefix)) {
+      path = path.substring(jarPrefix.length());
+    }
+    if (serializedPath.startsWith(filePrefix)) {
+      path = path.substring(filePrefix.length());
+    }
+    // Keep only one occurrence of "/" from the beginning if more than one exists.
+    path = Paths.get(path).toString();
+    int start = 0;
+    while (start + 1 < path.length()
+        && path.charAt(start) == '/'
+        && path.charAt(start + 1) == '/') {
+      start++;
+    }
+    return Paths.get(path.substring(start));
   }
 }

--- a/injector/src/main/java/edu/ucr/cs/riple/injector/SignatureMatcher.java
+++ b/injector/src/main/java/edu/ucr/cs/riple/injector/SignatureMatcher.java
@@ -26,6 +26,7 @@ package edu.ucr.cs.riple.injector;
 
 import com.github.javaparser.ast.body.CallableDeclaration;
 import com.github.javaparser.ast.type.Type;
+import edu.ucr.cs.riple.injector.util.ASTUtils;
 import java.util.List;
 import java.util.stream.Collectors;
 
@@ -44,7 +45,7 @@ public class SignatureMatcher {
    * @param signature Signature to process.
    */
   public SignatureMatcher(String signature) {
-    this.callableName = Helper.extractCallableName(signature);
+    this.callableName = ASTUtils.extractCallableName(signature);
     this.parameterTypes = extractParameterTypesFromSignature(signature);
   }
 
@@ -125,8 +126,8 @@ public class SignatureMatcher {
       if (signatureType.equals(callableType)) {
         continue;
       }
-      String simpleCallableType = Helper.simpleName(callableType);
-      String simpleSignatureType = Helper.simpleName(signatureType);
+      String simpleCallableType = ASTUtils.simpleName(callableType);
+      String simpleSignatureType = ASTUtils.simpleName(signatureType);
       if (simpleCallableType.equals(simpleSignatureType)) {
         continue;
       }

--- a/injector/src/main/java/edu/ucr/cs/riple/injector/changes/AddTypeUseMarkerAnnotation.java
+++ b/injector/src/main/java/edu/ucr/cs/riple/injector/changes/AddTypeUseMarkerAnnotation.java
@@ -22,19 +22,17 @@
 
 package edu.ucr.cs.riple.injector.changes;
 
-import static edu.ucr.cs.riple.injector.Helper.findSimpleNameRangeInTypeName;
-
 import com.github.javaparser.Range;
 import com.github.javaparser.ast.expr.AnnotationExpr;
 import com.github.javaparser.ast.nodeTypes.NodeWithAnnotations;
 import com.github.javaparser.ast.nodeTypes.NodeWithRange;
 import com.github.javaparser.ast.type.Type;
 import com.google.common.collect.ImmutableList;
-import edu.ucr.cs.riple.injector.Helper;
 import edu.ucr.cs.riple.injector.location.Location;
 import edu.ucr.cs.riple.injector.location.OnLocalVariable;
 import edu.ucr.cs.riple.injector.modifications.Insertion;
 import edu.ucr.cs.riple.injector.modifications.Modification;
+import edu.ucr.cs.riple.injector.util.TypeUtils;
 import java.util.Objects;
 import javax.annotation.Nullable;
 
@@ -61,10 +59,10 @@ public class AddTypeUseMarkerAnnotation extends TypeUseAnnotationChange implemen
   @Nullable
   @Override
   public Modification computeTextModificationOnType(Type type, AnnotationExpr annotationExpr) {
-    if (Helper.isAnnotatedWith(type, annotationExpr)) {
+    if (TypeUtils.isAnnotatedWith(type, annotationExpr)) {
       return null;
     }
-    Range range = findSimpleNameRangeInTypeName(type);
+    Range range = TypeUtils.findSimpleNameRangeInTypeName(type);
     if (range == null) {
       return null;
     }
@@ -76,17 +74,17 @@ public class AddTypeUseMarkerAnnotation extends TypeUseAnnotationChange implemen
       Modification computeTextModificationOnNode(T node, AnnotationExpr annotationExpr) {
     boolean addOnDeclaration =
         typeIndex.stream().anyMatch(index -> index.size() == 1 && index.get(0) == 0);
-    Type type = Helper.getTypeFromNode(node);
+    Type type = TypeUtils.getTypeFromNode(node);
     // For annotation on fully qualified name or inner class, the annotation is on the type. (e.g.
     // Map.@Annot Entry or java.util.@Annot Map)
     if (addOnDeclaration) {
-      if (Helper.isAnnotatedWith(node, annotationExpr)) {
+      if (TypeUtils.isAnnotatedWith(node, annotationExpr)) {
         return null;
       }
       // Javaparser does not know if an annotation is a type-use or declaration annotation.
       // While seeing "@Annot Object f", the type is not annotated and the annotation is on the
       // node.
-      if (Helper.isAnnotatedWith(type, annotationExpr)) {
+      if (TypeUtils.isAnnotatedWith(type, annotationExpr)) {
         return null;
       }
       return computeTextModificationOnType(type, annotationExpr);

--- a/injector/src/main/java/edu/ucr/cs/riple/injector/changes/ChangeVisitor.java
+++ b/injector/src/main/java/edu/ucr/cs/riple/injector/changes/ChangeVisitor.java
@@ -35,7 +35,6 @@ import com.github.javaparser.ast.body.VariableDeclarator;
 import com.github.javaparser.ast.expr.VariableDeclarationExpr;
 import com.github.javaparser.ast.type.ClassOrInterfaceType;
 import com.github.javaparser.utils.Pair;
-import edu.ucr.cs.riple.injector.Helper;
 import edu.ucr.cs.riple.injector.exceptions.TargetClassNotFound;
 import edu.ucr.cs.riple.injector.location.LocationVisitor;
 import edu.ucr.cs.riple.injector.location.OnClass;
@@ -45,6 +44,8 @@ import edu.ucr.cs.riple.injector.location.OnLocalVariable;
 import edu.ucr.cs.riple.injector.location.OnMethod;
 import edu.ucr.cs.riple.injector.location.OnParameter;
 import edu.ucr.cs.riple.injector.modifications.Modification;
+import edu.ucr.cs.riple.injector.util.ASTUtils;
+import edu.ucr.cs.riple.injector.util.TypeUtils;
 import java.util.List;
 import java.util.Optional;
 import java.util.Set;
@@ -91,7 +92,7 @@ public class ChangeVisitor
                   annotationMemberDeclaration -> {
                     if (annotationMemberDeclaration
                         .getNameAsString()
-                        .equals(Helper.extractCallableName(onMethod.method))) {
+                        .equals(ASTUtils.extractCallableName(onMethod.method))) {
                       ans.set(change.computeTextModificationOn(annotationMemberDeclaration));
                     }
                   }));
@@ -187,7 +188,7 @@ public class ChangeVisitor
       }
       // Static block initializers.
       Set<InitializerDeclaration> staticBlock =
-          Helper.getStaticInitializerBlocks((BodyDeclaration<?>) members.getParentNode().get());
+          ASTUtils.getStaticInitializerBlocks((BodyDeclaration<?>) members.getParentNode().get());
       // Locate the block with the target local variable.
       for (InitializerDeclaration block : staticBlock) {
         List<VariableDeclarationExpr> variables =
@@ -210,7 +211,7 @@ public class ChangeVisitor
         if (onLocalVariable.encMethod.matchesCallableDeclaration(callableDeclaration)) {
           // Find variable declaration in the callable declaration with the variable name.
           VariableDeclarationExpr variableDeclarationExpr =
-              Helper.locateVariableDeclarationExpr(callableDeclaration, onLocalVariable.varName);
+              ASTUtils.locateVariableDeclarationExpr(callableDeclaration, onLocalVariable.varName);
           if (variableDeclarationExpr == null) {
             return null;
           }
@@ -238,10 +239,10 @@ public class ChangeVisitor
       return null;
     }
     Set<ClassOrInterfaceType> typeStream =
-        Helper.getEnclosingOrInstantiatedTypes(optionalClass.get());
+        TypeUtils.getEnclosingOrInstantiatedTypes(optionalClass.get());
     for (ClassOrInterfaceType classOrInterfaceType : typeStream) {
-      if (Helper.simpleName(classOrInterfaceType.getNameAsString())
-          .equals(Helper.simpleName(onClassDeclaration.target))) {
+      if (ASTUtils.simpleName(classOrInterfaceType.getNameAsString())
+          .equals(ASTUtils.simpleName(onClassDeclaration.target))) {
         return change.computeTextModificationOn(classOrInterfaceType);
       }
     }
@@ -259,7 +260,7 @@ public class ChangeVisitor
   public Modification computeModification(ASTChange change) {
     NodeList<BodyDeclaration<?>> members;
     try {
-      members = Helper.getTypeDeclarationMembersByFlatName(cu, change.getLocation().clazz);
+      members = ASTUtils.getTypeDeclarationMembersByFlatName(cu, change.getLocation().clazz);
       if (members == null) {
         return null;
       }

--- a/injector/src/main/java/edu/ucr/cs/riple/injector/changes/Name.java
+++ b/injector/src/main/java/edu/ucr/cs/riple/injector/changes/Name.java
@@ -22,7 +22,7 @@
 
 package edu.ucr.cs.riple.injector.changes;
 
-import edu.ucr.cs.riple.injector.Helper;
+import edu.ucr.cs.riple.injector.util.ASTUtils;
 import java.util.Objects;
 
 /** A name that may consist of multiple identifiers. */
@@ -36,7 +36,7 @@ public class Name {
 
   public Name(String fullName) {
     this.fullName = fullName;
-    this.simpleName = Helper.simpleName(fullName);
+    this.simpleName = ASTUtils.simpleName(fullName);
   }
 
   @Override

--- a/injector/src/main/java/edu/ucr/cs/riple/injector/changes/RemoveTypeUseMarkerAnnotation.java
+++ b/injector/src/main/java/edu/ucr/cs/riple/injector/changes/RemoveTypeUseMarkerAnnotation.java
@@ -30,10 +30,10 @@ import com.github.javaparser.ast.type.ReferenceType;
 import com.github.javaparser.ast.type.Type;
 import com.github.javaparser.ast.type.WildcardType;
 import com.google.common.collect.ImmutableList;
-import edu.ucr.cs.riple.injector.Helper;
 import edu.ucr.cs.riple.injector.location.Location;
 import edu.ucr.cs.riple.injector.modifications.Deletion;
 import edu.ucr.cs.riple.injector.modifications.Modification;
+import edu.ucr.cs.riple.injector.util.TypeUtils;
 import java.util.Objects;
 import java.util.Optional;
 import javax.annotation.Nullable;
@@ -83,7 +83,7 @@ public class RemoveTypeUseMarkerAnnotation extends TypeUseAnnotationChange
   @Override
   public <T extends NodeWithAnnotations<?> & NodeWithRange<?>>
       Modification computeTextModificationOnNode(T node, AnnotationExpr annotationExpr) {
-    Type type = Helper.getTypeFromNode(node);
+    Type type = TypeUtils.getTypeFromNode(node);
 
     boolean removeOnDeclaration =
         typeIndex.stream().anyMatch(index -> index.size() == 1 && index.get(0) == 0);

--- a/injector/src/main/java/edu/ucr/cs/riple/injector/changes/TypeUseAnnotationChange.java
+++ b/injector/src/main/java/edu/ucr/cs/riple/injector/changes/TypeUseAnnotationChange.java
@@ -32,10 +32,10 @@ import com.github.javaparser.ast.nodeTypes.NodeWithAnnotations;
 import com.github.javaparser.ast.nodeTypes.NodeWithRange;
 import com.github.javaparser.ast.type.Type;
 import com.google.common.collect.ImmutableList;
-import edu.ucr.cs.riple.injector.Helper;
 import edu.ucr.cs.riple.injector.location.Location;
 import edu.ucr.cs.riple.injector.modifications.Modification;
 import edu.ucr.cs.riple.injector.modifications.MultiPositionModification;
+import edu.ucr.cs.riple.injector.util.TypeUtils;
 import java.util.HashSet;
 import java.util.Objects;
 import java.util.Set;
@@ -74,7 +74,7 @@ public abstract class TypeUseAnnotationChange extends AnnotationChange {
       Modification computeTextModificationOn(T node) {
     Set<Modification> modifications = new HashSet<>();
     AnnotationExpr annotationExpr = new MarkerAnnotationExpr(annotationName.simpleName);
-    Type type = Helper.getTypeFromNode(node);
+    Type type = TypeUtils.getTypeFromNode(node);
     Modification onNode = computeTextModificationOnNode(node, annotationExpr);
     if (onNode != null) {
       modifications.add(onNode);

--- a/injector/src/main/java/edu/ucr/cs/riple/injector/location/Location.java
+++ b/injector/src/main/java/edu/ucr/cs/riple/injector/location/Location.java
@@ -26,7 +26,7 @@ package edu.ucr.cs.riple.injector.location;
 
 import com.google.common.base.Preconditions;
 import com.google.common.collect.Sets;
-import edu.ucr.cs.riple.injector.Helper;
+import edu.ucr.cs.riple.injector.Printer;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.Arrays;
@@ -102,7 +102,7 @@ public abstract class Location {
       return null;
     }
     LocationKind type = LocationKind.getKind(values[0]);
-    Path path = Helper.deserializePath(values[5]);
+    Path path = Printer.deserializePath(values[5]);
     String clazz = values[1];
     switch (type) {
       case FIELD:

--- a/injector/src/main/java/edu/ucr/cs/riple/injector/location/OnClass.java
+++ b/injector/src/main/java/edu/ucr/cs/riple/injector/location/OnClass.java
@@ -24,7 +24,7 @@
 
 package edu.ucr.cs.riple.injector.location;
 
-import edu.ucr.cs.riple.injector.Helper;
+import edu.ucr.cs.riple.injector.Printer;
 import java.nio.file.Path;
 import java.util.regex.Pattern;
 
@@ -42,7 +42,7 @@ public class OnClass extends Location {
   }
 
   public OnClass(String path, String clazz) {
-    this(Helper.deserializePath(path), clazz);
+    this(Printer.deserializePath(path), clazz);
   }
 
   /**

--- a/injector/src/main/java/edu/ucr/cs/riple/injector/location/OnClassDeclaration.java
+++ b/injector/src/main/java/edu/ucr/cs/riple/injector/location/OnClassDeclaration.java
@@ -24,7 +24,7 @@
 
 package edu.ucr.cs.riple.injector.location;
 
-import edu.ucr.cs.riple.injector.Helper;
+import edu.ucr.cs.riple.injector.Printer;
 import java.nio.file.Path;
 import org.json.simple.JSONObject;
 
@@ -38,7 +38,7 @@ public class OnClassDeclaration extends Location {
   }
 
   public OnClassDeclaration(String path, String clazz, String target) {
-    super(LocationKind.CLASS_DECL, Helper.deserializePath(path), clazz);
+    super(LocationKind.CLASS_DECL, Printer.deserializePath(path), clazz);
     this.target = target;
   }
 

--- a/injector/src/main/java/edu/ucr/cs/riple/injector/location/OnField.java
+++ b/injector/src/main/java/edu/ucr/cs/riple/injector/location/OnField.java
@@ -25,7 +25,7 @@
 package edu.ucr.cs.riple.injector.location;
 
 import com.google.common.base.Preconditions;
-import edu.ucr.cs.riple.injector.Helper;
+import edu.ucr.cs.riple.injector.Printer;
 import java.nio.file.Path;
 import java.util.Collections;
 import java.util.Objects;
@@ -60,7 +60,7 @@ public class OnField extends Location {
   }
 
   public OnField(String path, String clazz, Set<String> variables) {
-    this(Helper.deserializePath(path), clazz, variables);
+    this(Printer.deserializePath(path), clazz, variables);
   }
 
   @Override

--- a/injector/src/main/java/edu/ucr/cs/riple/injector/location/OnLocalVariable.java
+++ b/injector/src/main/java/edu/ucr/cs/riple/injector/location/OnLocalVariable.java
@@ -24,7 +24,7 @@
 
 package edu.ucr.cs.riple.injector.location;
 
-import edu.ucr.cs.riple.injector.Helper;
+import edu.ucr.cs.riple.injector.Printer;
 import java.nio.file.Path;
 import java.util.Objects;
 import java.util.function.Consumer;
@@ -55,7 +55,7 @@ public class OnLocalVariable extends Location {
   }
 
   public OnLocalVariable(String path, String clazz, String encMethod, String varName) {
-    this(Helper.deserializePath(path), clazz, encMethod, varName);
+    this(Printer.deserializePath(path), clazz, encMethod, varName);
   }
 
   @Override

--- a/injector/src/main/java/edu/ucr/cs/riple/injector/location/OnMethod.java
+++ b/injector/src/main/java/edu/ucr/cs/riple/injector/location/OnMethod.java
@@ -25,8 +25,9 @@
 package edu.ucr.cs.riple.injector.location;
 
 import com.github.javaparser.ast.body.CallableDeclaration;
-import edu.ucr.cs.riple.injector.Helper;
+import edu.ucr.cs.riple.injector.Printer;
 import edu.ucr.cs.riple.injector.SignatureMatcher;
+import edu.ucr.cs.riple.injector.util.ASTUtils;
 import java.nio.file.Path;
 import java.util.Objects;
 import java.util.function.Consumer;
@@ -50,7 +51,7 @@ public class OnMethod extends Location {
   }
 
   public OnMethod(String path, String clazz, String method) {
-    this(Helper.deserializePath(path), clazz, method);
+    this(Printer.deserializePath(path), clazz, method);
   }
 
   /**
@@ -101,7 +102,7 @@ public class OnMethod extends Location {
    * @return True if this location is targeting a constructor.
    */
   public boolean isOnConstructor() {
-    return Helper.extractCallableName(method).equals(Helper.simpleName(clazz));
+    return ASTUtils.extractCallableName(method).equals(ASTUtils.simpleName(clazz));
   }
 
   @Override

--- a/injector/src/main/java/edu/ucr/cs/riple/injector/location/OnParameter.java
+++ b/injector/src/main/java/edu/ucr/cs/riple/injector/location/OnParameter.java
@@ -24,7 +24,7 @@
 
 package edu.ucr.cs.riple.injector.location;
 
-import edu.ucr.cs.riple.injector.Helper;
+import edu.ucr.cs.riple.injector.Printer;
 import java.nio.file.Path;
 import java.util.Objects;
 import java.util.function.Consumer;
@@ -48,7 +48,7 @@ public class OnParameter extends Location {
   }
 
   public OnParameter(String path, String clazz, String method, int index) {
-    this(Helper.deserializePath(path), clazz, method, index);
+    this(Printer.deserializePath(path), clazz, method, index);
   }
 
   @Override

--- a/injector/src/main/java/edu/ucr/cs/riple/injector/util/ASTUtils.java
+++ b/injector/src/main/java/edu/ucr/cs/riple/injector/util/ASTUtils.java
@@ -95,9 +95,9 @@ public class ASTUtils {
    */
   public static boolean isTypeDeclarationOrAnonymousClass(Node node) {
     return node instanceof ClassOrInterfaceDeclaration
-            || node instanceof EnumDeclaration
-            || node instanceof AnnotationDeclaration
-            || (node instanceof ObjectCreationExpr
+        || node instanceof EnumDeclaration
+        || node instanceof AnnotationDeclaration
+        || (node instanceof ObjectCreationExpr
             && ((ObjectCreationExpr) node).getAnonymousClassBody().isPresent());
   }
 
@@ -112,7 +112,7 @@ public class ASTUtils {
    * @throws TargetClassNotFound if the target class is not found.
    */
   public static NodeList<BodyDeclaration<?>> getTypeDeclarationMembersByFlatName(
-          CompilationUnit cu, String flatName) throws TargetClassNotFound {
+      CompilationUnit cu, String flatName) throws TargetClassNotFound {
     String packageName;
     Optional<PackageDeclaration> packageDeclaration = cu.getPackageDeclaration();
     if (packageDeclaration.isPresent()) {
@@ -121,13 +121,13 @@ public class ASTUtils {
       packageName = "";
     }
     Preconditions.checkArgument(
-            flatName.startsWith(packageName),
-            "Package name of compilation unit is incompatible with class name: "
-                    + packageName
-                    + " : "
-                    + flatName);
+        flatName.startsWith(packageName),
+        "Package name of compilation unit is incompatible with class name: "
+            + packageName
+            + " : "
+            + flatName);
     String flatNameExcludingPackageName =
-            packageName.isEmpty() ? flatName : flatName.substring(packageName.length() + 1);
+        packageName.isEmpty() ? flatName : flatName.substring(packageName.length() + 1);
     List<String> keys = new ArrayList<>(Arrays.asList(flatNameExcludingPackageName.split("\\$")));
     Node cursor = findTopLevelClassDeclarationOnCompilationUnit(cu, keys.get(0));
     keys.remove(0);
@@ -140,9 +140,9 @@ public class ASTUtils {
         cursor = findAnonymousClassOrEnumConstant(cursor, index);
       } else {
         cursor =
-                indexString.isEmpty()
-                        ? findDirectInnerClass(cursor, actualName)
-                        : findNonDirectInnerClass(cursor, actualName, index);
+            indexString.isEmpty()
+                ? findDirectInnerClass(cursor, actualName)
+                : findNonDirectInnerClass(cursor, actualName, index);
       }
     }
     return getMembersOfNode(cursor);
@@ -159,7 +159,7 @@ public class ASTUtils {
    */
   @Nullable
   public static VariableDeclarationExpr locateVariableDeclarationExpr(
-          CallableDeclaration<?> encMethod, String varName) {
+      CallableDeclaration<?> encMethod, String varName) {
     // Should not visit inner nodes of inner methods in the given method, since the given
     // method should be the closest enclosing method of the target local variable. Therefore, we
     // use DirectMethodParentIterator to skip inner methods.
@@ -169,7 +169,7 @@ public class ASTUtils {
       if (n instanceof VariableDeclarationExpr) {
         VariableDeclarationExpr v = (VariableDeclarationExpr) n;
         if (v.getVariables().stream()
-                .anyMatch(variableDeclarator -> variableDeclarator.getNameAsString().equals(varName))) {
+            .anyMatch(variableDeclarator -> variableDeclarator.getNameAsString().equals(varName))) {
           return v;
         }
       }
@@ -251,14 +251,14 @@ public class ASTUtils {
    * @return the static initializer blocks of the body declaration.
    */
   public static Set<InitializerDeclaration> getStaticInitializerBlocks(
-          BodyDeclaration<?> bodyDeclaration) {
+      BodyDeclaration<?> bodyDeclaration) {
     return bodyDeclaration.getChildNodes().stream()
-            .filter(
-                    node ->
-                            node instanceof InitializerDeclaration
-                                    && ((InitializerDeclaration) node).isStatic())
-            .map(node -> (InitializerDeclaration) node)
-            .collect(Collectors.toSet());
+        .filter(
+            node ->
+                node instanceof InitializerDeclaration
+                    && ((InitializerDeclaration) node).isStatic())
+        .map(node -> (InitializerDeclaration) node)
+        .collect(Collectors.toSet());
   }
 
   /**
@@ -273,7 +273,7 @@ public class ASTUtils {
    */
   @Nonnull
   private static TypeDeclaration<?> findTopLevelClassDeclarationOnCompilationUnit(
-          CompilationUnit tree, String name) throws TargetClassNotFound {
+      CompilationUnit tree, String name) throws TargetClassNotFound {
     Optional<ClassOrInterfaceDeclaration> classDeclaration = tree.getClassByName(name);
     if (classDeclaration.isPresent()) {
       return classDeclaration.get();
@@ -283,7 +283,7 @@ public class ASTUtils {
       return enumDeclaration.get();
     }
     Optional<AnnotationDeclaration> annotationDeclaration =
-            tree.getAnnotationDeclarationByName(name);
+        tree.getAnnotationDeclarationByName(name);
     if (annotationDeclaration.isPresent()) {
       return annotationDeclaration.get();
     }
@@ -309,12 +309,12 @@ public class ASTUtils {
   private static Node findDirectInnerClass(Node cursor, String name) throws TargetClassNotFound {
     List<Node> nodes = new ArrayList<>();
     cursor.walk(
-            Node.TreeTraversal.DIRECT_CHILDREN,
-            node -> {
-              if (isDeclarationWithName(node, name)) {
-                nodes.add(node);
-              }
-            });
+        Node.TreeTraversal.DIRECT_CHILDREN,
+        node -> {
+          if (isDeclarationWithName(node, name)) {
+            nodes.add(node);
+          }
+        });
     if (nodes.isEmpty()) {
       throw new TargetClassNotFound("Direct-Inner-Class", name, cursor);
     }
@@ -331,15 +331,15 @@ public class ASTUtils {
    * @throws TargetClassNotFound if the target class is not found.
    */
   private static Node findNonDirectInnerClass(Node cursor, String name, int index)
-          throws TargetClassNotFound {
+      throws TargetClassNotFound {
     final List<Node> candidates = new ArrayList<>();
     walk(
-            cursor,
-            candidates,
-            node ->
-                    isDeclarationWithName(node, name)
-                            && node.getParentNode().isPresent()
-                            && !node.getParentNode().get().equals(cursor));
+        cursor,
+        candidates,
+        node ->
+            isDeclarationWithName(node, name)
+                && node.getParentNode().isPresent()
+                && !node.getParentNode().get().equals(cursor));
     if (index >= candidates.size()) {
       throw new TargetClassNotFound("Non-Direct-Inner-Class", index + name, cursor);
     }
@@ -369,7 +369,7 @@ public class ASTUtils {
    * @throws TargetClassNotFound if the target class is not found.
    */
   private static Node findAnonymousClassOrEnumConstant(Node cursor, int index)
-          throws TargetClassNotFound {
+      throws TargetClassNotFound {
     final List<Node> candidates = new ArrayList<>();
     if (cursor instanceof EnumDeclaration) {
       // According to the Java language specification, enum constants are the first members of
@@ -383,14 +383,14 @@ public class ASTUtils {
       index -= constants.size();
     }
     walk(
-            cursor,
-            candidates,
-            node -> {
-              if (node instanceof ObjectCreationExpr) {
-                return ((ObjectCreationExpr) node).getAnonymousClassBody().isPresent();
-              }
-              return false;
-            });
+        cursor,
+        candidates,
+        node -> {
+          if (node instanceof ObjectCreationExpr) {
+            return ((ObjectCreationExpr) node).getAnonymousClassBody().isPresent();
+          }
+          return false;
+        });
     if (index >= candidates.size()) {
       throw new TargetClassNotFound("Top-Level-Anonymous-Class", "$" + index, cursor);
     }
@@ -459,15 +459,15 @@ public class ASTUtils {
    */
   private static void walk(Node cursor, List<Node> candidates, Predicate<Node> predicate) {
     cursor.walk(
-            Node.TreeTraversal.DIRECT_CHILDREN,
-            node -> {
-              if (!isTypeDeclarationOrAnonymousClass(node)) {
-                walk(node, candidates, predicate);
-              }
-              if (predicate.test(node)) {
-                candidates.add(node);
-              }
-            });
+        Node.TreeTraversal.DIRECT_CHILDREN,
+        node -> {
+          if (!isTypeDeclarationOrAnonymousClass(node)) {
+            walk(node, candidates, predicate);
+          }
+          if (predicate.test(node)) {
+            candidates.add(node);
+          }
+        });
   }
 
   /**

--- a/injector/src/main/java/edu/ucr/cs/riple/injector/util/ASTUtils.java
+++ b/injector/src/main/java/edu/ucr/cs/riple/injector/util/ASTUtils.java
@@ -88,26 +88,177 @@ public class ASTUtils {
   }
 
   /**
-   * Walks on the AST starting from the cursor in {@link
-   * com.github.javaparser.ast.Node.TreeTraversal#DIRECT_CHILDREN} manner, and adds all visiting
-   * nodes which holds the predicate.
+   * Checks if node is a type declaration or an anonymous class.
    *
-   * @param cursor starting node for traversal.
-   * @param candidates list of candidates, an empty list should be passed at the call site, accepted
-   *     visited nodes will be added to this list.
-   * @param predicate predicate to check if a node should be added to list of candidates.
+   * @param node Node instance.
+   * @return true if is a type declaration or an anonymous class and false otherwise.
    */
-  private static void walk(Node cursor, List<Node> candidates, Predicate<Node> predicate) {
-    cursor.walk(
-        Node.TreeTraversal.DIRECT_CHILDREN,
-        node -> {
-          if (!isTypeDeclarationOrAnonymousClass(node)) {
-            walk(node, candidates, predicate);
-          }
-          if (predicate.test(node)) {
-            candidates.add(node);
-          }
-        });
+  public static boolean isTypeDeclarationOrAnonymousClass(Node node) {
+    return node instanceof ClassOrInterfaceDeclaration
+        || node instanceof EnumDeclaration
+        || node instanceof AnnotationDeclaration
+        || (node instanceof ObjectCreationExpr
+            && ((ObjectCreationExpr) node).getAnonymousClassBody().isPresent());
+  }
+
+  /**
+   * Returns {@link NodeList} containing all members of an
+   * Enum/Interface/Class/AnonymousClass/Annotation Declaration by flat name from a compilation unit
+   * tree.
+   *
+   * @param cu Compilation Unit tree instance.
+   * @param flatName Flat name in string.
+   * @return {@link NodeList} containing all members
+   * @throws TargetClassNotFound if the target class is not found.
+   */
+  public static NodeList<BodyDeclaration<?>> getTypeDeclarationMembersByFlatName(
+      CompilationUnit cu, String flatName) throws TargetClassNotFound {
+    String packageName;
+    Optional<PackageDeclaration> packageDeclaration = cu.getPackageDeclaration();
+    if (packageDeclaration.isPresent()) {
+      packageName = packageDeclaration.get().getNameAsString();
+    } else {
+      packageName = "";
+    }
+    Preconditions.checkArgument(
+        flatName.startsWith(packageName),
+        "Package name of compilation unit is incompatible with class name: "
+            + packageName
+            + " : "
+            + flatName);
+    String flatNameExcludingPackageName =
+        packageName.isEmpty() ? flatName : flatName.substring(packageName.length() + 1);
+    List<String> keys = new ArrayList<>(Arrays.asList(flatNameExcludingPackageName.split("\\$")));
+    Node cursor = findTopLevelClassDeclarationOnCompilationUnit(cu, keys.get(0));
+    keys.remove(0);
+    for (String key : keys) {
+      String indexString = extractIntegerFromBeginningOfStringInString(key);
+      String actualName = key.substring(indexString.length());
+      int index = indexString.isEmpty() ? 0 : Integer.parseInt(indexString) - 1;
+      Preconditions.checkNotNull(cursor);
+      if (key.matches("\\d+")) {
+        cursor = findAnonymousClassOrEnumConstant(cursor, index);
+      } else {
+        cursor =
+            indexString.isEmpty()
+                ? findDirectInnerClass(cursor, actualName)
+                : findNonDirectInnerClass(cursor, actualName, index);
+      }
+    }
+    return getMembersOfNode(cursor);
+  }
+
+  /**
+   * Locates a variable declaration expression in the tree of a {@link CallableDeclaration} with the
+   * given name. Please note that the target local variable must be declared inside a callable
+   * declaration and local variables inside initializer blocks or lambdas are not supported.
+   *
+   * @param encMethod The enclosing method which the variable is declared in.
+   * @param varName The name of the variable.
+   * @return The variable declaration expression, or null if it is not found.
+   */
+  @Nullable
+  public static VariableDeclarationExpr locateVariableDeclarationExpr(
+      CallableDeclaration<?> encMethod, String varName) {
+    // Should not visit inner nodes of inner methods in the given method, since the given
+    // method should be the closest enclosing method of the target local variable. Therefore, we
+    // use DirectMethodParentIterator to skip inner methods.
+    Iterator<Node> treeIterator = new ASTUtils.DirectMethodParentIterator(encMethod);
+    while (treeIterator.hasNext()) {
+      Node n = treeIterator.next();
+      if (n instanceof VariableDeclarationExpr) {
+        VariableDeclarationExpr v = (VariableDeclarationExpr) n;
+        if (v.getVariables().stream()
+            .anyMatch(variableDeclarator -> variableDeclarator.getNameAsString().equals(varName))) {
+          return v;
+        }
+      }
+    }
+    return null;
+  }
+
+  /**
+   * Extracts simple name of fully qualified name. (e.g. for "{@code a.c.b.Foo<a.b.Bar, a.c.b.Foo>}"
+   * will return "{@code Foo<Bar,Foo>}").
+   *
+   * @param name Fully qualified name.
+   * @return simple name.
+   */
+  public static String simpleName(String name) {
+    int index = 0;
+    StringBuilder ans = new StringBuilder();
+    StringBuilder tmp = new StringBuilder();
+    while (index < name.length()) {
+      char c = name.charAt(index);
+      switch (c) {
+        case ' ':
+        case '<':
+        case '>':
+        case ',':
+          ans.append(tmp);
+          ans.append(c);
+          tmp = new StringBuilder();
+          break;
+        case '.':
+          tmp = new StringBuilder();
+          break;
+        default:
+          tmp.append(c);
+      }
+      index++;
+    }
+    if (!name.isEmpty()) {
+      ans.append(tmp);
+    }
+    return ans.toString().replaceAll(" ", "");
+  }
+
+  /**
+   * Extracts the package name from fully qualified name. (e.g. for "{@code a.c.b.Foo<a.b.Bar,
+   * a.c.b.Foo>}" will return "{@code a.c.b}").
+   *
+   * @param name Fully qualified name in String.
+   * @return Package name.
+   */
+  public static String getPackageName(String name) {
+    if (!name.contains(".")) {
+      return null;
+    }
+    List<String> verified = new ArrayList<>();
+    StringBuilder current = new StringBuilder();
+    int index = 0;
+    while (index < name.length()) {
+      char currentChar = name.charAt(index);
+      if (currentChar == '.') {
+        verified.add(current.toString());
+        current = new StringBuilder();
+      } else {
+        if (Character.isAlphabetic(currentChar) || Character.isDigit(currentChar)) {
+          current.append(currentChar);
+        } else {
+          break;
+        }
+      }
+      index++;
+    }
+    return String.join(".", verified);
+  }
+
+  /**
+   * Returns containing static initializer blocks of a {@link BodyDeclaration}.
+   *
+   * @param bodyDeclaration the body declaration to get its static initializer blocks.
+   * @return the static initializer blocks of the body declaration.
+   */
+  public static Set<InitializerDeclaration> getStaticInitializerBlocks(
+      BodyDeclaration<?> bodyDeclaration) {
+    return bodyDeclaration.getChildNodes().stream()
+        .filter(
+            node ->
+                node instanceof InitializerDeclaration
+                    && ((InitializerDeclaration) node).isStatic())
+        .map(node -> (InitializerDeclaration) node)
+        .collect(Collectors.toSet());
   }
 
   /**
@@ -196,20 +347,6 @@ public class ASTUtils {
   }
 
   /**
-   * Checks if node is a type declaration or an anonymous class.
-   *
-   * @param node Node instance.
-   * @return true if is a type declaration or an anonymous class and false otherwise.
-   */
-  public static boolean isTypeDeclarationOrAnonymousClass(Node node) {
-    return node instanceof ClassOrInterfaceDeclaration
-        || node instanceof EnumDeclaration
-        || node instanceof AnnotationDeclaration
-        || (node instanceof ObjectCreationExpr
-            && ((ObjectCreationExpr) node).getAnonymousClassBody().isPresent());
-  }
-
-  /**
    * Checks if the node is of type {@link TypeDeclaration} and a specific name.
    *
    * @param node input node.
@@ -292,82 +429,6 @@ public class ASTUtils {
   }
 
   /**
-   * Returns {@link NodeList} containing all members of an
-   * Enum/Interface/Class/AnonymousClass/Annotation Declaration by flat name from a compilation unit
-   * tree.
-   *
-   * @param cu Compilation Unit tree instance.
-   * @param flatName Flat name in string.
-   * @return {@link NodeList} containing all members
-   * @throws TargetClassNotFound if the target class is not found.
-   */
-  public static NodeList<BodyDeclaration<?>> getTypeDeclarationMembersByFlatName(
-      CompilationUnit cu, String flatName) throws TargetClassNotFound {
-    String packageName;
-    Optional<PackageDeclaration> packageDeclaration = cu.getPackageDeclaration();
-    if (packageDeclaration.isPresent()) {
-      packageName = packageDeclaration.get().getNameAsString();
-    } else {
-      packageName = "";
-    }
-    Preconditions.checkArgument(
-        flatName.startsWith(packageName),
-        "Package name of compilation unit is incompatible with class name: "
-            + packageName
-            + " : "
-            + flatName);
-    String flatNameExcludingPackageName =
-        packageName.isEmpty() ? flatName : flatName.substring(packageName.length() + 1);
-    List<String> keys = new ArrayList<>(Arrays.asList(flatNameExcludingPackageName.split("\\$")));
-    Node cursor = findTopLevelClassDeclarationOnCompilationUnit(cu, keys.get(0));
-    keys.remove(0);
-    for (String key : keys) {
-      String indexString = extractIntegerFromBeginningOfStringInString(key);
-      String actualName = key.substring(indexString.length());
-      int index = indexString.isEmpty() ? 0 : Integer.parseInt(indexString) - 1;
-      Preconditions.checkNotNull(cursor);
-      if (key.matches("\\d+")) {
-        cursor = findAnonymousClassOrEnumConstant(cursor, index);
-      } else {
-        cursor =
-            indexString.isEmpty()
-                ? findDirectInnerClass(cursor, actualName)
-                : findNonDirectInnerClass(cursor, actualName, index);
-      }
-    }
-    return getMembersOfNode(cursor);
-  }
-
-  /**
-   * Locates a variable declaration expression in the tree of a {@link CallableDeclaration} with the
-   * given name. Please note that the target local variable must be declared inside a callable
-   * declaration and local variables inside initializer blocks or lambdas are not supported.
-   *
-   * @param encMethod The enclosing method which the variable is declared in.
-   * @param varName The name of the variable.
-   * @return The variable declaration expression, or null if it is not found.
-   */
-  @Nullable
-  public static VariableDeclarationExpr locateVariableDeclarationExpr(
-      CallableDeclaration<?> encMethod, String varName) {
-    // Should not visit inner nodes of inner methods in the given method, since the given
-    // method should be the closest enclosing method of the target local variable. Therefore, we
-    // use DirectMethodParentIterator to skip inner methods.
-    Iterator<Node> treeIterator = new ASTUtils.DirectMethodParentIterator(encMethod);
-    while (treeIterator.hasNext()) {
-      Node n = treeIterator.next();
-      if (n instanceof VariableDeclarationExpr) {
-        VariableDeclarationExpr v = (VariableDeclarationExpr) n;
-        if (v.getVariables().stream()
-            .anyMatch(variableDeclarator -> variableDeclarator.getNameAsString().equals(varName))) {
-          return v;
-        }
-      }
-    }
-    return null;
-  }
-
-  /**
    * Extracts the integer at the start of string (e.g. 129uid -> 129).
    *
    * @param key string containing the integer.
@@ -387,94 +448,33 @@ public class ASTUtils {
   }
 
   /**
-   * Extracts simple name of fully qualified name. (e.g. for "{@code a.c.b.Foo<a.b.Bar, a.c.b.Foo>}"
-   * will return "{@code Foo<Bar,Foo>}").
+   * Walks on the AST starting from the cursor in {@link
+   * com.github.javaparser.ast.Node.TreeTraversal#DIRECT_CHILDREN} manner, and adds all visiting
+   * nodes which holds the predicate.
    *
-   * @param name Fully qualified name.
-   * @return simple name.
+   * @param cursor starting node for traversal.
+   * @param candidates list of candidates, an empty list should be passed at the call site, accepted
+   *     visited nodes will be added to this list.
+   * @param predicate predicate to check if a node should be added to list of candidates.
    */
-  public static String simpleName(String name) {
-    int index = 0;
-    StringBuilder ans = new StringBuilder();
-    StringBuilder tmp = new StringBuilder();
-    while (index < name.length()) {
-      char c = name.charAt(index);
-      switch (c) {
-        case ' ':
-        case '<':
-        case '>':
-        case ',':
-          ans.append(tmp);
-          ans.append(c);
-          tmp = new StringBuilder();
-          break;
-        case '.':
-          tmp = new StringBuilder();
-          break;
-        default:
-          tmp.append(c);
-      }
-      index++;
-    }
-    if (!name.isEmpty()) {
-      ans.append(tmp);
-    }
-    return ans.toString().replaceAll(" ", "");
-  }
-
-  /**
-   * Extracts the package name from fully qualified name. (e.g. for "{@code a.c.b.Foo<a.b.Bar,
-   * a.c.b.Foo>}" will return "{@code a.c.b}").
-   *
-   * @param name Fully qualified name in String.
-   * @return Package name.
-   */
-  public static String getPackageName(String name) {
-    if (!name.contains(".")) {
-      return null;
-    }
-    List<String> verified = new ArrayList<>();
-    StringBuilder current = new StringBuilder();
-    int index = 0;
-    while (index < name.length()) {
-      char currentChar = name.charAt(index);
-      if (currentChar == '.') {
-        verified.add(current.toString());
-        current = new StringBuilder();
-      } else {
-        if (Character.isAlphabetic(currentChar) || Character.isDigit(currentChar)) {
-          current.append(currentChar);
-        } else {
-          break;
-        }
-      }
-      index++;
-    }
-    return String.join(".", verified);
-  }
-
-  /**
-   * Returns containing static initializer blocks of a {@link BodyDeclaration}.
-   *
-   * @param bodyDeclaration the body declaration to get its static initializer blocks.
-   * @return the static initializer blocks of the body declaration.
-   */
-  public static Set<InitializerDeclaration> getStaticInitializerBlocks(
-      BodyDeclaration<?> bodyDeclaration) {
-    return bodyDeclaration.getChildNodes().stream()
-        .filter(
-            node ->
-                node instanceof InitializerDeclaration
-                    && ((InitializerDeclaration) node).isStatic())
-        .map(node -> (InitializerDeclaration) node)
-        .collect(Collectors.toSet());
+  private static void walk(Node cursor, List<Node> candidates, Predicate<Node> predicate) {
+    cursor.walk(
+        Node.TreeTraversal.DIRECT_CHILDREN,
+        node -> {
+          if (!isTypeDeclarationOrAnonymousClass(node)) {
+            walk(node, candidates, predicate);
+          }
+          if (predicate.test(node)) {
+            candidates.add(node);
+          }
+        });
   }
 
   /**
    * Iterates over children of a {@link CallableDeclaration} in a depth-first manner, skipping over
    * any {@link BodyDeclaration}.
    */
-  public static final class DirectMethodParentIterator implements Iterator<Node> {
+  private static final class DirectMethodParentIterator implements Iterator<Node> {
 
     private final ArrayDeque<Node> deque = new ArrayDeque<>();
 

--- a/injector/src/main/java/edu/ucr/cs/riple/injector/util/TypeUtils.java
+++ b/injector/src/main/java/edu/ucr/cs/riple/injector/util/TypeUtils.java
@@ -51,6 +51,7 @@ import java.util.stream.Stream;
 
 /** Utility class for working with types in Java and Javaparser. */
 public class TypeUtils {
+
   /**
    * Extracts the type of the given node implementing {@link NodeWithAnnotations}.
    *

--- a/injector/src/main/java/edu/ucr/cs/riple/injector/util/TypeUtils.java
+++ b/injector/src/main/java/edu/ucr/cs/riple/injector/util/TypeUtils.java
@@ -1,0 +1,178 @@
+/*
+ * MIT License
+ *
+ * Copyright (c) 2024 Nima Karimipour
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+package edu.ucr.cs.riple.injector.util;
+
+import com.github.javaparser.Range;
+import com.github.javaparser.ast.Node;
+import com.github.javaparser.ast.NodeList;
+import com.github.javaparser.ast.body.BodyDeclaration;
+import com.github.javaparser.ast.body.ClassOrInterfaceDeclaration;
+import com.github.javaparser.ast.body.FieldDeclaration;
+import com.github.javaparser.ast.body.MethodDeclaration;
+import com.github.javaparser.ast.body.Parameter;
+import com.github.javaparser.ast.body.VariableDeclarator;
+import com.github.javaparser.ast.expr.AnnotationExpr;
+import com.github.javaparser.ast.expr.ObjectCreationExpr;
+import com.github.javaparser.ast.expr.VariableDeclarationExpr;
+import com.github.javaparser.ast.nodeTypes.NodeWithAnnotations;
+import com.github.javaparser.ast.type.ArrayType;
+import com.github.javaparser.ast.type.ClassOrInterfaceType;
+import com.github.javaparser.ast.type.PrimitiveType;
+import com.github.javaparser.ast.type.ReferenceType;
+import com.github.javaparser.ast.type.Type;
+import com.github.javaparser.ast.type.WildcardType;
+import com.google.common.base.Preconditions;
+import java.util.Optional;
+import java.util.Set;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+/** Utility class for working with types in Java and Javaparser. */
+public class TypeUtils {
+  /**
+   * Extracts the type of the given node implementing {@link NodeWithAnnotations}.
+   *
+   * @param node the node.
+   * @return the type of the node.
+   */
+  public static Type getTypeFromNode(NodeWithAnnotations<?> node) {
+    if (node instanceof MethodDeclaration) {
+      return ((MethodDeclaration) node).getType();
+    }
+    if (node instanceof FieldDeclaration) {
+      FieldDeclaration fd = (FieldDeclaration) node;
+      Preconditions.checkArgument(!fd.getVariables().isEmpty());
+      return fd.getVariables().get(0).getType();
+    }
+    if (node instanceof VariableDeclarationExpr) {
+      NodeList<VariableDeclarator> decls = ((VariableDeclarationExpr) node).getVariables();
+      for (VariableDeclarator v : decls) {
+        // All declared variables in a VariableDeclarationExpr have the same type.
+        // (e.g. Foo a, b, c;)
+        return v.getType();
+      }
+    }
+    if (node instanceof Parameter) {
+      return ((Parameter) node).getType();
+    }
+    if (node instanceof VariableDeclarator) {
+      return ((VariableDeclarator) node).getType();
+    }
+    if (node instanceof Type) {
+      return ((Type) node);
+    }
+    return null;
+  }
+
+  /**
+   * Helper method to check if a type is annotated with a specific annotation.
+   *
+   * @param type the type to check its annotations.
+   * @param expr the annotation to check.
+   * @return true if the node is annotated with the annotation.
+   */
+  public static boolean isAnnotatedWith(Type type, AnnotationExpr expr) {
+    if (type instanceof WildcardType) {
+      Optional<ReferenceType> extendedType = ((WildcardType) type).getExtendedType();
+      return extendedType.isPresent() && isAnnotatedWith(extendedType.get(), expr);
+    }
+    return type.getAnnotations().stream().anyMatch(annot -> annot.getName().equals(expr.getName()));
+  }
+
+  /**
+   * Helper method to check if a node is annotated with a specific annotation.
+   *
+   * @param node the node to check its annotations.
+   * @param expr the annotation to check.
+   * @return true if the node is annotated with the annotation.
+   */
+  public static boolean isAnnotatedWith(NodeWithAnnotations<?> node, AnnotationExpr expr) {
+    return node.getAnnotations().stream().anyMatch(annot -> annot.getName().equals(expr.getName()));
+  }
+
+  /**
+   * Finds the range of the simple name in the fully qualified name of the given type in the source
+   * code. This is used to insert the type use annotations before the type simple name.
+   *
+   * @param type the type to find its range
+   * @return the range of the type or null if the type does not have a range.
+   */
+  public static Range findSimpleNameRangeInTypeName(Type type) {
+    if (type instanceof ClassOrInterfaceType) {
+      ClassOrInterfaceType classOrInterfaceType = (ClassOrInterfaceType) type;
+      if (classOrInterfaceType.getName().getRange().isEmpty()) {
+        return null;
+      }
+      return ((ClassOrInterfaceType) type).getName().getRange().get();
+    }
+    if (type instanceof ArrayType) {
+      return findSimpleNameRangeInTypeName(((ArrayType) type).getComponentType());
+    }
+    if (type instanceof PrimitiveType) {
+      if (type.getRange().isEmpty()) {
+        return null;
+      }
+      return type.getRange().get();
+    }
+    if (type instanceof WildcardType) {
+      if (((WildcardType) type).getExtendedType().isEmpty()) {
+        // type is simply: "?"
+        return type.getRange().get();
+      }
+      return findSimpleNameRangeInTypeName(((WildcardType) type).getExtendedType().orElse(null));
+    }
+    throw new RuntimeException(
+        "Unexpected type to get range from: " + type + " : " + type.getClass());
+  }
+
+  /**
+   * Retrieves the types associated with the given node. If the node is a class or interface
+   * declaration, it returns the implemented and extended types. If the node is an object creation
+   * expression, it returns the type of the object being created. In all other cases, an empty set
+   * is returned.
+   *
+   * @param node the node from which to extract types, typically a {@code BodyDeclaration<?>} (like
+   *     a class or interface declaration) or an {@code ObjectCreationExpr}.
+   * @return a set of {@code ClassOrInterfaceType} representing the implemented, extended, or
+   *     instantiated types, or an empty set if the node does not contain relevant type information.
+   */
+  public static Set<ClassOrInterfaceType> getEnclosingOrInstantiatedTypes(Node node) {
+    Stream<ClassOrInterfaceType> typeStream = null;
+    if (node instanceof BodyDeclaration<?>) {
+      BodyDeclaration<?> enclosingClass = (BodyDeclaration<?>) node;
+      if (enclosingClass instanceof ClassOrInterfaceDeclaration) {
+        ClassOrInterfaceDeclaration declaration = (ClassOrInterfaceDeclaration) enclosingClass;
+        typeStream =
+            Stream.concat(
+                declaration.getImplementedTypes().stream(),
+                declaration.getExtendedTypes().stream());
+      }
+    }
+    if (node instanceof ObjectCreationExpr) {
+      typeStream = Stream.of(((ObjectCreationExpr) node).getType());
+    }
+    return typeStream == null ? Set.of() : typeStream.collect(Collectors.toSet());
+  }
+}

--- a/injector/src/main/java/edu/ucr/cs/riple/injector/util/TypeUtils.java
+++ b/injector/src/main/java/edu/ucr/cs/riple/injector/util/TypeUtils.java
@@ -24,7 +24,9 @@
 
 package edu.ucr.cs.riple.injector.util;
 
+import com.github.javaparser.JavaToken;
 import com.github.javaparser.Range;
+import com.github.javaparser.TokenRange;
 import com.github.javaparser.ast.Node;
 import com.github.javaparser.ast.NodeList;
 import com.github.javaparser.ast.body.BodyDeclaration;
@@ -129,7 +131,16 @@ public class TypeUtils {
       return ((ClassOrInterfaceType) type).getName().getRange().get();
     }
     if (type instanceof ArrayType) {
-      return findSimpleNameRangeInTypeName(((ArrayType) type).getComponentType());
+      Optional<TokenRange> tokenRange = type.getTokenRange();
+      if (tokenRange.isEmpty()) {
+        return null;
+      }
+      for (JavaToken javaToken : tokenRange.get()) {
+        if (javaToken.asString().equals("[")) {
+          return javaToken.getRange().orElse(null);
+        }
+      }
+      return null;
     }
     if (type instanceof PrimitiveType) {
       if (type.getRange().isEmpty()) {

--- a/injector/src/test/java/edu/ucr/cs/riple/injector/ClassSearchTest.java
+++ b/injector/src/test/java/edu/ucr/cs/riple/injector/ClassSearchTest.java
@@ -33,6 +33,7 @@ import edu.ucr.cs.riple.injector.changes.AddMarkerAnnotation;
 import edu.ucr.cs.riple.injector.exceptions.TargetClassNotFound;
 import edu.ucr.cs.riple.injector.location.OnField;
 import edu.ucr.cs.riple.injector.location.OnMethod;
+import edu.ucr.cs.riple.injector.util.ASTUtils;
 import java.io.ByteArrayOutputStream;
 import java.io.PrintStream;
 import java.nio.charset.Charset;
@@ -501,7 +502,7 @@ public class ClassSearchTest extends BaseInjectorTest {
     TargetClassNotFound thrown =
         assertThrows(
             TargetClassNotFound.class,
-            () -> Helper.getTypeDeclarationMembersByFlatName(tree, "com.test.NotIncluded"));
+            () -> ASTUtils.getTypeDeclarationMembersByFlatName(tree, "com.test.NotIncluded"));
     assertTrue(thrown.getMessage().contains(expectedErrorMessage));
   }
 


### PR DESCRIPTION
This PR splits all utility methods in `Helper` class into two different classes. (`TypeUtils` and `ASTUtils`). This can wait for #251.

This PR only moves methods among classes, there is not a single change on any method declaration or implementation.