### PR TITLE
Resolve Issue with Arrays of Primitive Component Types as Type Arguments

### DIFF
--- a/injector/src/test/java/edu/ucr/cs/riple/injector/TypeUseAnnotationTest.java
+++ b/injector/src/test/java/edu/ucr/cs/riple/injector/TypeUseAnnotationTest.java
@@ -821,4 +821,28 @@ public class TypeUseAnnotationTest extends BaseInjectorTest {
                 "javax.annotation.Nullable"))
         .start();
   }
+
+  @Test
+  public void nullableArrayAdditionOnComponentWithArrayOfPrimitiveType() {
+    injectorTestHelper
+        .addInput(
+            "Foo.java",
+            "package test;",
+            "import javax.annotation.Nullable;",
+            "public class Foo {",
+            "   List<char[]> h3 = new ArrayList<>();",
+            "}")
+        .expectOutput(
+            "package test;",
+            "import javax.annotation.Nullable;",
+            "public class Foo {",
+            "   List<@Nullable char[]> h3 = new ArrayList<>();",
+            "}")
+        .addChanges(
+            new AddTypeUseMarkerAnnotation(
+                new OnField("Foo.java", "test.Foo", Collections.singleton("h3")),
+                "javax.annotation.Nullable",
+                ImmutableList.of(ImmutableList.of(1, 1, 0))))
+        .start();
+  }
 }


### PR DESCRIPTION
This PR fixes a bug in handling type arguments where arrays with primitive component types were incorrectly processed. The issue stemmed from an assumption that type arguments could not be primitives. However, we missed the case where an array used as a type argument can have a primitive component type.

To resolve this, the relevant method in TypeArgChangeVisitor is now overridden to account for arrays with primitive component types used as type arguments. This ensures that the appropriate changes are applied consistently.