### PR TITLE
Fix Duplicate @Nullable Annotations by fixing Equality Check

### DIFF
--- a/injector/src/main/java/edu/ucr/cs/riple/injector/changes/AddMarkerAnnotation.java
+++ b/injector/src/main/java/edu/ucr/cs/riple/injector/changes/AddMarkerAnnotation.java
@@ -23,7 +23,6 @@
 package edu.ucr.cs.riple.injector.changes;
 
 import com.github.javaparser.Range;
-import com.github.javaparser.ast.NodeList;
 import com.github.javaparser.ast.expr.AnnotationExpr;
 import com.github.javaparser.ast.expr.MarkerAnnotationExpr;
 import com.github.javaparser.ast.nodeTypes.NodeWithAnnotations;
@@ -31,6 +30,7 @@ import com.github.javaparser.ast.nodeTypes.NodeWithRange;
 import edu.ucr.cs.riple.injector.location.Location;
 import edu.ucr.cs.riple.injector.modifications.Insertion;
 import edu.ucr.cs.riple.injector.modifications.Modification;
+import edu.ucr.cs.riple.injector.util.TypeUtils;
 import java.util.Objects;
 import javax.annotation.Nullable;
 
@@ -53,13 +53,10 @@ public class AddMarkerAnnotation extends AnnotationChange implements AddAnnotati
       return null;
     }
     Range range = node.getRange().get();
-    NodeList<AnnotationExpr> annotations = node.getAnnotations();
     AnnotationExpr annotationExpr = new MarkerAnnotationExpr(annotationName.simpleName);
 
     // Check if annot already exists.
-    boolean annotAlreadyExists =
-        annotations.stream().anyMatch(annot -> annot.equals(annotationExpr));
-    if (annotAlreadyExists) {
+    if (TypeUtils.isAnnotatedWith(node, annotationExpr)) {
       return null;
     }
     return new Insertion(annotationExpr.toString(), range.begin);

--- a/injector/src/test/java/edu/ucr/cs/riple/injector/BasicTest.java
+++ b/injector/src/test/java/edu/ucr/cs/riple/injector/BasicTest.java
@@ -26,7 +26,9 @@ package edu.ucr.cs.riple.injector;
 
 import edu.ucr.cs.riple.injector.changes.ASTChange;
 import edu.ucr.cs.riple.injector.changes.AddMarkerAnnotation;
+import edu.ucr.cs.riple.injector.location.OnField;
 import edu.ucr.cs.riple.injector.location.OnMethod;
+import java.util.Collections;
 import org.junit.Test;
 
 public class BasicTest extends BaseInjectorTest {
@@ -86,6 +88,31 @@ public class BasicTest extends BaseInjectorTest {
         .addChanges(
             new AddMarkerAnnotation(
                 new OnMethod("Foo.java", "test.Foo", "test(java.lang.Object)"),
+                "javax.annotation.Nullable"))
+        .start();
+  }
+
+  @Test
+  public void ignoreCommentsOnAnnotationEqualCheckTest() {
+    injectorTestHelper
+        .addInput(
+            "Foo.java",
+            "package edu.ucr;",
+            "import javax.annotation.Nullable;",
+            "public class Test {",
+            "   @Nullable @GuardedBy(\"this\") // Either a RuntimeException, non-fatal Error, or IOException.",
+            "  private  Throwable creationFailure;",
+            "}")
+        .expectOutput(
+            "package edu.ucr;",
+            "import javax.annotation.Nullable;",
+            "public class Test {",
+            "   @Nullable @GuardedBy(\"this\") // Either a RuntimeException, non-fatal Error, or IOException.",
+            "  private  Throwable creationFailure;",
+            "}")
+        .addChanges(
+            new AddMarkerAnnotation(
+                new OnField("Foo.java", "edu.ucr.Test", Collections.singleton("creationFailure")),
                 "javax.annotation.Nullable"))
         .start();
   }

--- a/injector/src/test/java/edu/ucr/cs/riple/injector/BasicTest.java
+++ b/injector/src/test/java/edu/ucr/cs/riple/injector/BasicTest.java
@@ -100,15 +100,15 @@ public class BasicTest extends BaseInjectorTest {
             "package edu.ucr;",
             "import javax.annotation.Nullable;",
             "public class Test {",
-            "   @Nullable @GuardedBy(\"this\") // Either a RuntimeException, non-fatal Error, or IOException.",
-            "  private  Throwable creationFailure;",
+            "  @Nullable @GuardedBy(\"this\") // Either a RuntimeException, non-fatal Error, or IOException.",
+            "  private Throwable creationFailure;",
             "}")
         .expectOutput(
             "package edu.ucr;",
             "import javax.annotation.Nullable;",
             "public class Test {",
-            "   @Nullable @GuardedBy(\"this\") // Either a RuntimeException, non-fatal Error, or IOException.",
-            "  private  Throwable creationFailure;",
+            "  @Nullable @GuardedBy(\"this\") // Either a RuntimeException, non-fatal Error, or IOException.",
+            "  private Throwable creationFailure;",
             "}")
         .addChanges(
             new AddMarkerAnnotation(


### PR DESCRIPTION
This PR resolves #262 where Annotator adds duplicate `@Nullable` annotations to fields that already have a `@Nullable` annotation with comments.

The issue occurred because the equality check for annotations was based on the entire annotation node, which includes comments, rather than just the annotation's name. This PR updates the equality check logic to compare annotations based solely on their names, ensuring that existing annotations are correctly detected and duplicates are avoided.