### PR TITLE
Change json dependency from json-simple to GSON

### DIFF
--- a/annotator-core/build.gradle
+++ b/annotator-core/build.gradle
@@ -36,18 +36,17 @@ application {
 }
 
 dependencies {
-
     implementation project(':injector')
     implementation project(':annotator-scanner')
     implementation deps.build.guava
-    implementation deps.build.json
+    implementation deps.build.gson
     implementation deps.build.progressbar
     implementation deps.build.javaparser
     implementation deps.build.commonscli
-    testImplementation deps.build.commonsio
-    testImplementation 'junit:junit:4.13.1'
-    testImplementation deps.test.mockito
 
+    testImplementation deps.build.commonsio
+    testImplementation deps.test.junit
+    testImplementation deps.test.mockito
 }
 
 // Exclude formatting files under resources
@@ -95,7 +94,7 @@ shadowJar {
 }
 
 // Exclude tests not supported by Java 11.
-if(JavaVersion.current().isJava11()){
+if (JavaVersion.current().isJava11()) {
     // exclude Java17Test which is designed to test Java 17 features.
     test {
         filter {

--- a/annotator-core/src/main/java/edu/ucr/cs/riple/core/Config.java
+++ b/annotator-core/src/main/java/edu/ucr/cs/riple/core/Config.java
@@ -542,7 +542,7 @@ public class Config {
             .getAsString();
     this.initializerAnnot =
         getValueFromKey(jsonObject, "ANNOTATION:INITIALIZER")
-            .orElse("javax.annotation.Nullable")
+            .orElse("com.uber.nullaway.annotations.Initializer")
             .getAsString();
     this.globalDir =
         Paths.get(getValueFromKey(jsonObject, "OUTPUT_DIR").orElse(null).getAsString());

--- a/annotator-core/src/main/java/edu/ucr/cs/riple/core/Config.java
+++ b/annotator-core/src/main/java/edu/ucr/cs/riple/core/Config.java
@@ -30,7 +30,9 @@ import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Sets;
 import com.google.gson.JsonArray;
 import com.google.gson.JsonElement;
+import com.google.gson.JsonNull;
 import com.google.gson.JsonObject;
+import com.google.gson.JsonPrimitive;
 import edu.ucr.cs.riple.core.module.ModuleConfiguration;
 import edu.ucr.cs.riple.core.util.Utility;
 import edu.ucr.cs.riple.scanner.generatedcode.SourceType;
@@ -520,50 +522,52 @@ public class Config {
   public Config(Path configPath) {
     Preconditions.checkNotNull(configPath);
     JsonObject jsonObject = Utility.parseJson(configPath);
-    this.checkerName = getValueFromKey(jsonObject, "CHECKER", String.class).orElse(null);
-    this.depth = getValueFromKey(jsonObject, "DEPTH", Long.class).orElse((long) 1).intValue();
-    this.chain = getValueFromKey(jsonObject, "CHAIN", Boolean.class).orElse(false);
+    this.checkerName = getValueFromKey(jsonObject, "CHECKER").orElse(null).getAsString();
+    this.depth = getValueFromKey(jsonObject, "DEPTH").orElse(1).getAsInt();
+    this.chain = getValueFromKey(jsonObject, "CHAIN").orElse(false).getAsBoolean();
     this.redirectBuildOutputToStdErr =
-        getValueFromKey(jsonObject, "REDIRECT_BUILD_OUTPUT_TO_STDERR", Boolean.class).orElse(false);
-    this.useCache = getValueFromKey(jsonObject, "CACHE", Boolean.class).orElse(true);
+        getValueFromKey(jsonObject, "REDIRECT_BUILD_OUTPUT_TO_STDERR").orElse(false).getAsBoolean();
+    this.useCache = getValueFromKey(jsonObject, "CACHE").orElse(true).getAsBoolean();
     this.useParallelGraphProcessor =
-        getValueFromKey(jsonObject, "PARALLEL_PROCESSING", Boolean.class).orElse(true);
+        getValueFromKey(jsonObject, "PARALLEL_PROCESSING").orElse(true).getAsBoolean();
     this.useImpactCache =
-        getValueFromKey(jsonObject, "CACHE_IMPACT_ACTIVATION", Boolean.class).orElse(false);
+        getValueFromKey(jsonObject, "CACHE_IMPACT_ACTIVATION").orElse(false).getAsBoolean();
     this.exhaustiveSearch =
-        getValueFromKey(jsonObject, "EXHAUSTIVE_SEARCH", Boolean.class).orElse(true);
-    this.disableOuterLoop = !getValueFromKey(jsonObject, "OUTER_LOOP", Boolean.class).orElse(false);
-    this.bailout = getValueFromKey(jsonObject, "BAILOUT", Boolean.class).orElse(true);
+        getValueFromKey(jsonObject, "EXHAUSTIVE_SEARCH").orElse(true).getAsBoolean();
+    this.disableOuterLoop = !getValueFromKey(jsonObject, "OUTER_LOOP").orElse(false).getAsBoolean();
+    this.bailout = getValueFromKey(jsonObject, "BAILOUT").orElse(true).getAsBoolean();
     this.nullableAnnot =
-        getValueFromKey(jsonObject, "ANNOTATION:NULLABLE", String.class)
-            .orElse("javax.annotation.Nullable");
+        getValueFromKey(jsonObject, "ANNOTATION:NULLABLE")
+            .orElse("javax.annotation.Nullable")
+            .getAsString();
     this.initializerAnnot =
-        getValueFromKey(jsonObject, "ANNOTATION:INITIALIZER", String.class)
-            .orElse("javax.annotation.Nullable");
+        getValueFromKey(jsonObject, "ANNOTATION:INITIALIZER")
+            .orElse("javax.annotation.Nullable")
+            .getAsString();
     this.globalDir =
-        Paths.get(getValueFromKey(jsonObject, "OUTPUT_DIR", String.class).orElse(null));
+        Paths.get(getValueFromKey(jsonObject, "OUTPUT_DIR").orElse(null).getAsString());
     List<ModuleConfiguration> moduleConfigurationList =
         getArrayValueFromKey(
                 jsonObject,
                 "CONFIG_PATHS",
-                instance ->
-                    ModuleConfiguration.buildFromJson(getNextModuleUniqueID(), globalDir, instance),
-                ModuleConfiguration.class)
+                moduleInfo ->
+                    ModuleConfiguration.buildFromJson(
+                        getNextModuleUniqueID(), globalDir, moduleInfo))
             .orElse(Collections.emptyList());
     this.target = moduleConfigurationList.get(0);
-    this.buildCommand = getValueFromKey(jsonObject, "BUILD_COMMAND", String.class).orElse(null);
+    this.buildCommand = getValueFromKey(jsonObject, "BUILD_COMMAND").orElse(null).getAsString();
     this.downStreamDependenciesAnalysisActivated =
-        getValueFromKey(jsonObject, "DOWNSTREAM_DEPENDENCY_ANALYSIS:ACTIVATION", Boolean.class)
-            .orElse(false);
+        getValueFromKey(jsonObject, "DOWNSTREAM_DEPENDENCY_ANALYSIS:ACTIVATION")
+            .orElse(false)
+            .getAsBoolean();
     this.downstreamDependenciesBuildCommand =
-        getValueFromKey(jsonObject, "DOWNSTREAM_DEPENDENCY_ANALYSIS:BUILD_COMMAND", String.class)
-            .orElse(null);
+        getValueFromKey(jsonObject, "DOWNSTREAM_DEPENDENCY_ANALYSIS:BUILD_COMMAND")
+            .orElse(null)
+            .getAsString();
     String nullawayLibraryModelLoaderPathString =
-        getValueFromKey(
-                jsonObject,
-                "DOWNSTREAM_DEPENDENCY_ANALYSIS:LIBRARY_MODEL_LOADER_PATH",
-                String.class)
-            .orElse(null);
+        getValueFromKey(jsonObject, "DOWNSTREAM_DEPENDENCY_ANALYSIS:LIBRARY_MODEL_LOADER_PATH")
+            .orElse(null)
+            .getAsString();
     this.nullawayLibraryModelLoaderPath =
         nullawayLibraryModelLoaderPathString == null
             ? null
@@ -572,34 +576,32 @@ public class Config {
     this.mode =
         AnalysisMode.parseMode(
             this.downStreamDependenciesAnalysisActivated,
-            getValueFromKey(
-                    jsonObject, "DOWNSTREAM_DEPENDENCY_ANALYSIS:ANALYSIS_MODE", String.class)
-                .orElse("default"));
+            getValueFromKey(jsonObject, "DOWNSTREAM_DEPENDENCY_ANALYSIS:ANALYSIS_MODE")
+                .orElse("default")
+                .getAsString());
 
     this.downstreamConfigurations = ImmutableSet.copyOf(moduleConfigurationList);
     this.moduleCounterID = 0;
     this.suppressRemainingErrors =
-        getValueFromKey(jsonObject, "SUPPRESS_REMAINING_ERRORS", Boolean.class).orElse(false);
+        getValueFromKey(jsonObject, "SUPPRESS_REMAINING_ERRORS").orElse(false).getAsBoolean();
     this.inferenceActivated =
-        getValueFromKey(jsonObject, "INFERENCE_ACTIVATION", Boolean.class).orElse(true);
+        getValueFromKey(jsonObject, "INFERENCE_ACTIVATION").orElse(true).getAsBoolean();
     this.nullUnMarkedAnnotation =
-        getValueFromKey(jsonObject, "ANNOTATION:NULL_UNMARKED", String.class)
-            .orElse("org.jspecify.annotations.NullUnmarked");
+        getValueFromKey(jsonObject, "ANNOTATION:NULL_UNMARKED")
+            .orElse("org.jspecify.annotations.NullUnmarked")
+            .getAsString();
     boolean lombokCodeDetectorActivated =
-        getValueFromKey(
-                jsonObject, "PROCESSORS:" + SourceType.LOMBOK.name() + ":ACTIVATION", Boolean.class)
-            .orElse(true);
+        getValueFromKey(jsonObject, "PROCESSORS:" + SourceType.LOMBOK.name() + ":ACTIVATION")
+            .orElse(true)
+            .getAsBoolean();
     this.generatedCodeDetectors =
         lombokCodeDetectorActivated ? Sets.immutableEnumSet(SourceType.LOMBOK) : ImmutableSet.of();
     this.languageLevel =
-        getLanguageLevel(getValueFromKey(jsonObject, "LANGUAGE_LEVEL", String.class).orElse("17"));
+        getLanguageLevel(getValueFromKey(jsonObject, "LANGUAGE_LEVEL").orElse("17").getAsString());
     this.nonnullAnnotations =
         ImmutableSet.copyOf(
             getArrayValueFromKey(
-                    jsonObject,
-                    "ANNOTATION:NONNULL",
-                    json -> json.get("NONNULL").toString(),
-                    String.class)
+                    jsonObject, "ANNOTATION:NONNULL", json -> json.get("NONNULL").getAsString())
                 .orElse(List.of()));
   }
 
@@ -626,9 +628,9 @@ public class Config {
     formatter.printHelp("Annotator context Flags", options);
   }
 
-  private <T> Config.OrElse<T> getValueFromKey(JsonObject json, String key, Class<T> klass) {
+  private OrElse getValueFromKey(JsonObject json, String key) {
     if (json == null) {
-      return new OrElse<>(null, klass);
+      return new OrElse(JsonNull.INSTANCE);
     }
     try {
       ArrayList<String> keys = new ArrayList<>(Arrays.asList(key.split(":")));
@@ -637,66 +639,77 @@ public class Config {
           json = (JsonObject) json.get(keys.get(0));
           keys.remove(0);
         } else {
-          return new OrElse<>(null, klass);
+          return new OrElse(JsonNull.INSTANCE);
         }
       }
       return json.keySet().contains(keys.get(0))
-          ? new OrElse<>(json.get(keys.get(0)), klass)
-          : new OrElse<>(null, klass);
+          ? new OrElse(json.get(keys.get(0)))
+          : new OrElse(JsonNull.INSTANCE);
     } catch (Exception e) {
-      return new OrElse<>(null, klass);
+      return new OrElse(JsonNull.INSTANCE);
     }
   }
 
   private <T> ListOrElse<T> getArrayValueFromKey(
-      JsonObject json, String key, Function<JsonObject, T> mapper, Class<T> klass) {
+      JsonObject json, String key, Function<JsonObject, T> mapper) {
     if (json == null) {
-      return new ListOrElse<>(null, klass);
+      return new ListOrElse<>(Stream.of());
     }
-    OrElse<T> jsonValue = getValueFromKey(json, key, klass);
-    if (jsonValue.value == null) {
-      return new ListOrElse<>(null, klass);
+    OrElse jsonValue = getValueFromKey(json, key);
+    if (jsonValue.value.equals(JsonNull.INSTANCE)) {
+      return new ListOrElse<>(Stream.of());
     } else {
       if (jsonValue.value instanceof JsonArray) {
         return new ListOrElse<>(
             StreamSupport.stream(((JsonArray) jsonValue.value).spliterator(), false)
-                .map(JsonElement::getAsJsonObject)
-                .map(mapper),
-            klass);
+                .map(jsonElement -> mapper.apply(jsonElement.getAsJsonObject())));
       }
       throw new IllegalStateException(
           "Expected type to be json array, found: " + jsonValue.value.getClass());
     }
   }
 
-  private static class OrElse<T> {
-    private final Object value;
-    private final Class<T> klass;
+  private static class OrElse {
 
-    OrElse(Object value, Class<T> klass) {
+    private final JsonElement value;
+
+    OrElse(JsonElement value) {
       this.value = value;
-      this.klass = klass;
     }
 
-    T orElse(T other) {
-      return value == null ? other : klass.cast(this.value);
+    @SuppressWarnings("SameParameterValue")
+    JsonPrimitive orElse(int other) {
+      return value.equals(JsonNull.INSTANCE)
+          ? new JsonPrimitive(other)
+          : value.getAsJsonPrimitive();
+    }
+
+    JsonPrimitive orElse(String other) {
+      other = other == null ? "" : other;
+      return value.equals(JsonNull.INSTANCE)
+          ? new JsonPrimitive(other)
+          : value.getAsJsonPrimitive();
+    }
+
+    JsonPrimitive orElse(boolean other) {
+      return value.equals(JsonNull.INSTANCE)
+          ? new JsonPrimitive(other)
+          : value.getAsJsonPrimitive();
     }
   }
 
   private static class ListOrElse<T> {
-    private final Stream<?> value;
-    private final Class<T> klass;
+    private final Stream<T> value;
 
-    ListOrElse(Stream<?> value, Class<T> klass) {
+    ListOrElse(Stream<T> value) {
       this.value = value;
-      this.klass = klass;
     }
 
     List<T> orElse(List<T> other) {
       if (value == null) {
         return other;
       } else {
-        return this.value.map(klass::cast).collect(Collectors.toList());
+        return this.value.collect(Collectors.toList());
       }
     }
   }

--- a/annotator-core/src/main/java/edu/ucr/cs/riple/core/Config.java
+++ b/annotator-core/src/main/java/edu/ucr/cs/riple/core/Config.java
@@ -677,23 +677,9 @@ public class Config {
       this.value = value;
     }
 
-    @SuppressWarnings("SameParameterValue")
-    JsonPrimitive orElse(int other) {
+    JsonPrimitive orElse(Object other) {
       return value.equals(JsonNull.INSTANCE)
-          ? new JsonPrimitive(other)
-          : value.getAsJsonPrimitive();
-    }
-
-    JsonPrimitive orElse(String other) {
-      other = other == null ? "" : other;
-      return value.equals(JsonNull.INSTANCE)
-          ? new JsonPrimitive(other)
-          : value.getAsJsonPrimitive();
-    }
-
-    JsonPrimitive orElse(boolean other) {
-      return value.equals(JsonNull.INSTANCE)
-          ? new JsonPrimitive(other)
+          ? new JsonPrimitive(String.valueOf(other))
           : value.getAsJsonPrimitive();
     }
   }

--- a/annotator-core/src/main/java/edu/ucr/cs/riple/core/Config.java
+++ b/annotator-core/src/main/java/edu/ucr/cs/riple/core/Config.java
@@ -523,7 +523,7 @@ public class Config {
     Preconditions.checkNotNull(configPath);
     JsonObject jsonObject = Utility.parseJson(configPath);
     this.checkerName = getValueFromKey(jsonObject, "CHECKER").orElse(null).getAsString();
-    this.depth = getValueFromKey(jsonObject, "DEPTH").orElse(1).getAsInt();
+    this.depth = getValueFromKey(jsonObject, "DEPTH").orElse(5).getAsInt();
     this.chain = getValueFromKey(jsonObject, "CHAIN").orElse(false).getAsBoolean();
     this.redirectBuildOutputToStdErr =
         getValueFromKey(jsonObject, "REDIRECT_BUILD_OUTPUT_TO_STDERR").orElse(false).getAsBoolean();

--- a/annotator-core/src/main/java/edu/ucr/cs/riple/core/Config.java
+++ b/annotator-core/src/main/java/edu/ucr/cs/riple/core/Config.java
@@ -50,7 +50,6 @@ import java.util.function.Function;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 import java.util.stream.StreamSupport;
-
 import org.apache.commons.cli.CommandLine;
 import org.apache.commons.cli.CommandLineParser;
 import org.apache.commons.cli.DefaultParser;
@@ -650,7 +649,7 @@ public class Config {
   }
 
   private <T> ListOrElse<T> getArrayValueFromKey(
-          JsonObject json, String key, Function<JsonObject, T> mapper, Class<T> klass) {
+      JsonObject json, String key, Function<JsonObject, T> mapper, Class<T> klass) {
     if (json == null) {
       return new ListOrElse<>(null, klass);
     }
@@ -660,8 +659,10 @@ public class Config {
     } else {
       if (jsonValue.value instanceof JsonArray) {
         return new ListOrElse<>(
-                StreamSupport.stream(((JsonArray) jsonValue.value).spliterator(), false).map(JsonElement::getAsJsonObject).map(mapper), klass
-        );
+            StreamSupport.stream(((JsonArray) jsonValue.value).spliterator(), false)
+                .map(JsonElement::getAsJsonObject)
+                .map(mapper),
+            klass);
       }
       throw new IllegalStateException(
           "Expected type to be json array, found: " + jsonValue.value.getClass());
@@ -765,14 +766,13 @@ public class Config {
       json.addProperty("INFERENCE_ACTIVATION", inferenceActivated);
       json.addProperty("LANGUAGE_LEVEL", languageLevel.name().split("_")[1]);
       JsonArray configPathsJson = new JsonArray();
-          configPaths
-              .forEach(
-                  info -> {
-                    JsonObject res = new JsonObject();
-                    res.addProperty("CHECKER", info.checkerConfig.toString());
-                    res.addProperty("SCANNER", info.scannerConfig.toString());
-                    configPathsJson.add(res);
-                  });
+      configPaths.forEach(
+          info -> {
+            JsonObject res = new JsonObject();
+            res.addProperty("CHECKER", info.checkerConfig.toString());
+            res.addProperty("SCANNER", info.scannerConfig.toString());
+            configPathsJson.add(res);
+          });
       json.add("CONFIG_PATHS", configPathsJson);
       JsonObject downstreamDependency = new JsonObject();
       downstreamDependency.addProperty("ACTIVATION", downStreamDependenciesAnalysisActivated);

--- a/annotator-core/src/main/java/edu/ucr/cs/riple/core/module/ModuleConfiguration.java
+++ b/annotator-core/src/main/java/edu/ucr/cs/riple/core/module/ModuleConfiguration.java
@@ -29,7 +29,8 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.Objects;
-import org.json.simple.JSONObject;
+
+import com.google.gson.JsonObject;
 
 /** Container class to hold paths to checker and scanner config files. */
 public class ModuleConfiguration {
@@ -57,9 +58,9 @@ public class ModuleConfiguration {
    * @param jsonObject Json Object to retrieve values.
    * @return An instance of {@link ModuleConfiguration}.
    */
-  public static ModuleConfiguration buildFromJson(int id, Path globalDir, JSONObject jsonObject) {
-    String checkerConfigPath = (String) jsonObject.get("CHECKER");
-    String scannerConfigPath = (String) jsonObject.get("SCANNER");
+  public static ModuleConfiguration buildFromJson(int id, Path globalDir, JsonObject jsonObject) {
+    String checkerConfigPath = jsonObject.get("CHECKER").getAsString();
+    String scannerConfigPath = jsonObject.get("SCANNER").getAsString();
     if (checkerConfigPath == null || scannerConfigPath == null) {
       throw new IllegalArgumentException(
           "Both paths to NullAway and Scanner config files must be set with CHECKER and SCANNER keys!");

--- a/annotator-core/src/main/java/edu/ucr/cs/riple/core/module/ModuleConfiguration.java
+++ b/annotator-core/src/main/java/edu/ucr/cs/riple/core/module/ModuleConfiguration.java
@@ -24,13 +24,12 @@
 
 package edu.ucr.cs.riple.core.module;
 
+import com.google.gson.JsonObject;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.Objects;
-
-import com.google.gson.JsonObject;
 
 /** Container class to hold paths to checker and scanner config files. */
 public class ModuleConfiguration {

--- a/annotator-core/src/main/java/edu/ucr/cs/riple/core/registries/index/Fix.java
+++ b/annotator-core/src/main/java/edu/ucr/cs/riple/core/registries/index/Fix.java
@@ -26,6 +26,7 @@ package edu.ucr.cs.riple.core.registries.index;
 
 import com.google.common.base.Preconditions;
 import com.google.common.collect.ImmutableSet;
+import com.google.gson.JsonObject;
 import edu.ucr.cs.riple.injector.changes.ASTChange;
 import edu.ucr.cs.riple.injector.changes.AddAnnotation;
 import edu.ucr.cs.riple.injector.location.Location;
@@ -38,7 +39,6 @@ import java.util.Objects;
 import java.util.Set;
 import java.util.function.Consumer;
 import java.util.stream.Collectors;
-import org.json.simple.JSONObject;
 
 /**
  * Stores information suggesting adding @Nullable on an element in source code. These suggestions
@@ -185,7 +185,7 @@ public class Fix {
    *
    * @return Json instance.
    */
-  public JSONObject getJson() {
+  public JsonObject getJson() {
     return changes.iterator().next().getLocation().accept(new LocationToJsonVisitor(), null);
   }
 

--- a/annotator-core/src/main/java/edu/ucr/cs/riple/core/util/JsonParser.java
+++ b/annotator-core/src/main/java/edu/ucr/cs/riple/core/util/JsonParser.java
@@ -34,7 +34,6 @@ import java.io.IOException;
 import java.nio.charset.Charset;
 import java.nio.file.Files;
 import java.nio.file.Path;
-import java.util.Arrays;
 import java.util.List;
 import java.util.function.Function;
 import java.util.stream.Collectors;
@@ -77,17 +76,18 @@ public class JsonParser {
    */
   public OrElse getValueFromKey(String key) {
     JsonObject current = json;
-    List<String> keys = Arrays.asList(key.split(":"));
-    while (keys.size() != 1) {
-      if (current.keySet().contains(keys.get(0))) {
-        current = (JsonObject) current.get(keys.get(0));
-        keys.remove(0);
+    String[] keys = key.split(":");
+    int index = 0;
+    while (index != keys.length - 1) {
+      if (current.keySet().contains(keys[index])) {
+        current = (JsonObject) current.get(keys[index]);
+        index++;
       } else {
         return new OrElse(JsonNull.INSTANCE);
       }
     }
-    return current.keySet().contains(keys.get(0))
-        ? new OrElse(current.get(keys.get(0)))
+    return current.keySet().contains(keys[index])
+        ? new OrElse(current.get(keys[index]))
         : new OrElse(JsonNull.INSTANCE);
   }
 

--- a/annotator-core/src/main/java/edu/ucr/cs/riple/core/util/JsonParser.java
+++ b/annotator-core/src/main/java/edu/ucr/cs/riple/core/util/JsonParser.java
@@ -30,7 +30,6 @@ import com.google.gson.JsonNull;
 import com.google.gson.JsonObject;
 import com.google.gson.JsonPrimitive;
 import java.nio.file.Path;
-import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 import java.util.function.Function;
@@ -74,22 +73,18 @@ public class JsonParser {
    */
   public OrElse getValueFromKey(String key) {
     JsonObject current = json;
-    try {
-      ArrayList<String> keys = new ArrayList<>(Arrays.asList(key.split(":")));
-      while (keys.size() != 1) {
-        if (current.keySet().contains(keys.get(0))) {
-          current = (JsonObject) current.get(keys.get(0));
-          keys.remove(0);
-        } else {
-          return new OrElse(JsonNull.INSTANCE);
-        }
+    List<String> keys = Arrays.asList(key.split(":"));
+    while (keys.size() != 1) {
+      if (current.keySet().contains(keys.get(0))) {
+        current = (JsonObject) current.get(keys.get(0));
+        keys.remove(0);
+      } else {
+        return new OrElse(JsonNull.INSTANCE);
       }
-      return current.keySet().contains(keys.get(0))
-          ? new OrElse(current.get(keys.get(0)))
-          : new OrElse(JsonNull.INSTANCE);
-    } catch (Exception e) {
-      return new OrElse(JsonNull.INSTANCE);
     }
+    return current.keySet().contains(keys.get(0))
+        ? new OrElse(current.get(keys.get(0)))
+        : new OrElse(JsonNull.INSTANCE);
   }
 
   /**

--- a/annotator-core/src/main/java/edu/ucr/cs/riple/core/util/JsonParser.java
+++ b/annotator-core/src/main/java/edu/ucr/cs/riple/core/util/JsonParser.java
@@ -29,6 +29,10 @@ import com.google.gson.JsonElement;
 import com.google.gson.JsonNull;
 import com.google.gson.JsonObject;
 import com.google.gson.JsonPrimitive;
+import com.google.gson.JsonSyntaxException;
+import java.io.IOException;
+import java.nio.charset.Charset;
+import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.Arrays;
 import java.util.List;
@@ -49,7 +53,7 @@ public class JsonParser {
    * @param path The path to the JSON file.
    */
   public JsonParser(Path path) {
-    this.json = Utility.parseJson(path);
+    this.json = parseJson(path);
   }
 
   /**
@@ -58,7 +62,7 @@ public class JsonParser {
    * @param content The content of the JSON file.
    */
   public JsonParser(String content) {
-    this.json = Utility.parseJson(content);
+    this.json = parseJson(content);
   }
 
   /**
@@ -111,6 +115,36 @@ public class JsonParser {
       }
       throw new IllegalStateException(
           "Expected type to be json array, found: " + jsonValue.value.getClass());
+    }
+  }
+
+  /**
+   * Parses a file in json format and returns as a JsonObject.
+   *
+   * @param path The path to the file.
+   * @return The JsonObject parsed from the file.
+   */
+  private static JsonObject parseJson(Path path) {
+    try {
+      return com.google.gson.JsonParser.parseReader(
+              Files.newBufferedReader(path, Charset.defaultCharset()))
+          .getAsJsonObject();
+    } catch (JsonSyntaxException | IOException e) {
+      throw new RuntimeException("Error in parsing json at path: " + path, e);
+    }
+  }
+
+  /**
+   * Parses a string in json format and returns as a JsonObject.
+   *
+   * @param content The content to parse.
+   * @return The JsonObject parsed from the content.
+   */
+  private static JsonObject parseJson(String content) {
+    try {
+      return com.google.gson.JsonParser.parseString(content).getAsJsonObject();
+    } catch (JsonSyntaxException e) {
+      throw new RuntimeException("Error in parsing: " + content, e);
     }
   }
 

--- a/annotator-core/src/main/java/edu/ucr/cs/riple/core/util/JsonParser.java
+++ b/annotator-core/src/main/java/edu/ucr/cs/riple/core/util/JsonParser.java
@@ -1,0 +1,189 @@
+/*
+ * MIT License
+ *
+ * Copyright (c) 2025 Nima Karimipour
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+package edu.ucr.cs.riple.core.util;
+
+import com.google.gson.JsonArray;
+import com.google.gson.JsonElement;
+import com.google.gson.JsonNull;
+import com.google.gson.JsonObject;
+import com.google.gson.JsonPrimitive;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+import java.util.stream.StreamSupport;
+
+/** A utility class for parsing JSON files. */
+public class JsonParser {
+
+  /** The JSON object to parse. */
+  private final JsonObject json;
+
+  /**
+   * Creates a new JsonParser with the given path.
+   *
+   * @param path The path to the JSON file.
+   */
+  public JsonParser(Path path) {
+    this.json = Utility.parseJson(path);
+  }
+
+  /**
+   * Creates a new JsonParser with the given content.
+   *
+   * @param content The content of the JSON file.
+   */
+  public JsonParser(String content) {
+    this.json = Utility.parseJson(content);
+  }
+
+  /**
+   * Used to retrieve a value from a key in the JSON object, the given key should be in the format
+   * of "key1:key2:key3". The method recursively searches for the key in the JSON object. It returns
+   * a {@link OrElse} object that can be used to retrieve the value or a default value if the key
+   * does not exist.
+   *
+   * @param key The key to search for in the JSON object.
+   * @return An {@link OrElse} object that can be used to retrieve the value or a default value if
+   *     the key does not exist.
+   */
+  public OrElse getValueFromKey(String key) {
+    JsonObject current = json;
+    try {
+      ArrayList<String> keys = new ArrayList<>(Arrays.asList(key.split(":")));
+      while (keys.size() != 1) {
+        if (current.keySet().contains(keys.get(0))) {
+          current = (JsonObject) current.get(keys.get(0));
+          keys.remove(0);
+        } else {
+          return new OrElse(JsonNull.INSTANCE);
+        }
+      }
+      return current.keySet().contains(keys.get(0))
+          ? new OrElse(current.get(keys.get(0)))
+          : new OrElse(JsonNull.INSTANCE);
+    } catch (Exception e) {
+      return new OrElse(JsonNull.INSTANCE);
+    }
+  }
+
+  /**
+   * Used to retrieve an array of values from a key in the JSON object, the given key should be in
+   * the format of "key1:key2:key3". The method recursively searches for the key in the JSON object.
+   * It returns a {@link ListOrElse} object that can be used to retrieve the value or a default
+   * value if the key does not exist.
+   *
+   * @param key The key to search for in the JSON object.
+   * @param mapper The function to map the JSON object to the desired type.
+   * @return A {@link ListOrElse} object that can be used to retrieve the value or a default value
+   *     if the key does not exist.
+   * @param <T> The type of the array elements.
+   */
+  public <T> ListOrElse<T> getArrayValueFromKey(String key, Function<JsonObject, T> mapper) {
+    OrElse jsonValue = getValueFromKey(key);
+    if (jsonValue.value.equals(JsonNull.INSTANCE)) {
+      return new ListOrElse<>(Stream.of());
+    } else {
+      if (jsonValue.value instanceof JsonArray) {
+        return new ListOrElse<>(
+            StreamSupport.stream(((JsonArray) jsonValue.value).spliterator(), false)
+                .map(jsonElement -> mapper.apply(jsonElement.getAsJsonObject())));
+      }
+      throw new IllegalStateException(
+          "Expected type to be json array, found: " + jsonValue.value.getClass());
+    }
+  }
+
+  /**
+   * A utility class to retrieve a value from a JSON object or a default value if the key does not
+   * exist.
+   */
+  public static class OrElse {
+
+    /** The JSON element retrieved from the JSON object. */
+    private final JsonElement value;
+
+    /**
+     * Creates a new OrElse object with the given JSON element.
+     *
+     * @param value The retrieved JSON element.
+     */
+    private OrElse(JsonElement value) {
+      this.value = value;
+    }
+
+    /**
+     * Returns the value as a {@link JsonPrimitive} if it is not {@link JsonNull}, otherwise returns
+     * the default value.
+     *
+     * @param defaultValue The default value to return if the key does not exist.
+     * @return The value as a {@link JsonPrimitive} if it is not {@link JsonNull}, otherwise returns
+     *     the default value.
+     */
+    public JsonPrimitive orElse(Object defaultValue) {
+      return value.equals(JsonNull.INSTANCE)
+          ? new JsonPrimitive(String.valueOf(defaultValue))
+          : value.getAsJsonPrimitive();
+    }
+  }
+
+  /**
+   * A utility class to retrieve an array of values from a JSON object or a default value if the key
+   * does not exist.
+   *
+   * @param <T> The type of the array elements.
+   */
+  public static class ListOrElse<T> {
+
+    /** The stream of values retrieved from the JSON object. */
+    private final Stream<T> value;
+
+    /**
+     * Creates a new ListOrElse object with the given stream of values.
+     *
+     * @param value The retrieved stream of values.
+     */
+    private ListOrElse(Stream<T> value) {
+      this.value = value;
+    }
+
+    /**
+     * Returns the values as a list if it is not null, otherwise returns the default value.
+     *
+     * @param defaultValue The default value to return if the key does not exist.
+     * @return The values as a list if it is not null, otherwise returns the default value.
+     */
+    public List<T> orElse(List<T> defaultValue) {
+      if (value == null) {
+        return defaultValue;
+      } else {
+        return this.value.collect(Collectors.toList());
+      }
+    }
+  }
+}

--- a/annotator-core/src/main/java/edu/ucr/cs/riple/core/util/Utility.java
+++ b/annotator-core/src/main/java/edu/ucr/cs/riple/core/util/Utility.java
@@ -94,13 +94,21 @@ public class Utility {
     JsonObject result = new JsonObject();
     JsonArray reportsJson = new JsonArray();
     // Sort reports based on the overall effect in descending order.
-    List<Report> sorted = reports.stream().sorted((r1, r2) -> Integer.compare(r2.getOverallEffect(context.config), r1.getOverallEffect(context.config))).collect(Collectors.toList());
+    List<Report> sorted =
+        reports.stream()
+            .sorted(
+                (r1, r2) ->
+                    Integer.compare(
+                        r2.getOverallEffect(context.config), r1.getOverallEffect(context.config)))
+            .collect(Collectors.toList());
     for (Report report : sorted) {
       JsonObject reportJson = report.root.getJson();
       reportJson.addProperty("LOCAL EFFECT", report.localEffect);
       reportJson.addProperty("OVERALL EFFECT", report.getOverallEffect(context.config));
-      reportJson.addProperty("Upper Bound EFFECT", report.getUpperBoundEffectOnDownstreamDependencies());
-      reportJson.addProperty("Lower Bound EFFECT", report.getLowerBoundEffectOnDownstreamDependencies());
+      reportJson.addProperty(
+          "Upper Bound EFFECT", report.getUpperBoundEffectOnDownstreamDependencies());
+      reportJson.addProperty(
+          "Lower Bound EFFECT", report.getLowerBoundEffectOnDownstreamDependencies());
       reportJson.addProperty("FINISHED", !report.requiresFurtherProcess(context.config));
       JsonArray followUps = new JsonArray();
       if (context.config.chain && report.localEffect < 1) {
@@ -299,12 +307,14 @@ public class Utility {
 
   /**
    * Parses a file in json format and returns as a JsonObject.
+   *
    * @param path The path to the file.
    * @return The JsonObject parsed from the file.
    */
   public static JsonObject parseJson(Path path) {
     try {
-      return JsonParser.parseReader(Files.newBufferedReader(path, Charset.defaultCharset())).getAsJsonObject();
+      return JsonParser.parseReader(Files.newBufferedReader(path, Charset.defaultCharset()))
+          .getAsJsonObject();
     } catch (Exception e) {
       throw new RuntimeException("Error in reading/parsing context at path: " + path, e);
     }

--- a/annotator-core/src/main/java/edu/ucr/cs/riple/core/util/Utility.java
+++ b/annotator-core/src/main/java/edu/ucr/cs/riple/core/util/Utility.java
@@ -29,6 +29,7 @@ import com.google.common.collect.ImmutableSet;
 import com.google.gson.JsonArray;
 import com.google.gson.JsonObject;
 import com.google.gson.JsonParser;
+import com.google.gson.JsonSyntaxException;
 import edu.ucr.cs.riple.core.Config;
 import edu.ucr.cs.riple.core.Context;
 import edu.ucr.cs.riple.core.Report;
@@ -315,8 +316,22 @@ public class Utility {
     try {
       return JsonParser.parseReader(Files.newBufferedReader(path, Charset.defaultCharset()))
           .getAsJsonObject();
-    } catch (Exception e) {
-      throw new RuntimeException("Error in reading/parsing context at path: " + path, e);
+    } catch (JsonSyntaxException | IOException e) {
+      throw new RuntimeException("Error in parsing json at path: " + path, e);
+    }
+  }
+
+  /**
+   * Parses a string in json format and returns as a JsonObject.
+   *
+   * @param content The content to parse.
+   * @return The JsonObject parsed from the content.
+   */
+  public static JsonObject parseJson(String content) {
+    try {
+      return JsonParser.parseString(content).getAsJsonObject();
+    } catch (JsonSyntaxException e) {
+      throw new RuntimeException("Error in parsing: " + content, e);
     }
   }
 }

--- a/annotator-core/src/main/java/edu/ucr/cs/riple/core/util/Utility.java
+++ b/annotator-core/src/main/java/edu/ucr/cs/riple/core/util/Utility.java
@@ -28,8 +28,6 @@ import com.google.common.base.Preconditions;
 import com.google.common.collect.ImmutableSet;
 import com.google.gson.JsonArray;
 import com.google.gson.JsonObject;
-import com.google.gson.JsonParser;
-import com.google.gson.JsonSyntaxException;
 import edu.ucr.cs.riple.core.Config;
 import edu.ucr.cs.riple.core.Context;
 import edu.ucr.cs.riple.core.Report;
@@ -303,35 +301,6 @@ public class Utility {
       return stream.collect(Collectors.toList());
     } catch (IOException e) {
       throw new RuntimeException("Exception while reading file: " + path, e);
-    }
-  }
-
-  /**
-   * Parses a file in json format and returns as a JsonObject.
-   *
-   * @param path The path to the file.
-   * @return The JsonObject parsed from the file.
-   */
-  public static JsonObject parseJson(Path path) {
-    try {
-      return JsonParser.parseReader(Files.newBufferedReader(path, Charset.defaultCharset()))
-          .getAsJsonObject();
-    } catch (JsonSyntaxException | IOException e) {
-      throw new RuntimeException("Error in parsing json at path: " + path, e);
-    }
-  }
-
-  /**
-   * Parses a string in json format and returns as a JsonObject.
-   *
-   * @param content The content to parse.
-   * @return The JsonObject parsed from the content.
-   */
-  public static JsonObject parseJson(String content) {
-    try {
-      return JsonParser.parseString(content).getAsJsonObject();
-    } catch (JsonSyntaxException e) {
-      throw new RuntimeException("Error in parsing: " + content, e);
     }
   }
 }

--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -32,24 +32,24 @@ def defaultErrorProneVersion =  JavaVersion.current() >= JavaVersion.VERSION_11 
 
 
 def versions = [
-        errorProne             : defaultErrorProneVersion,
-        errorProneApi          : project.hasProperty("epApiVersion") ? epApiVersion : oldestErrorProneApi,
-        autoService            : "1.0-rc7",
-        javaparser             : "3.26.2",
-        gson                   : "2.11.0",
-        guava                  : "31.0.1-jre",
-        cli                    : "1.5.0",
-        commonsio              : "2.11.0",
-        progressbar            : "0.9.2",
-        junitjupiter          : "5.7.2",
-        nullaway               : "0.10.19",
-        mockito                : "5.2.0",
-        junit                  : "4.13.2"
+        errorProne              : defaultErrorProneVersion,
+        errorProneApi           : project.hasProperty("epApiVersion") ? epApiVersion : oldestErrorProneApi,
+        autoService             : "1.0-rc7",
+        javaparser              : "3.26.2",
+        gson                    : "2.11.0",
+        guava                   : "31.0.1-jre",
+        cli                     : "1.5.0",
+        commonsio               : "2.11.0",
+        progressbar             : "0.9.2",
+        junitjupiter            : "5.7.2",
+        nullaway                : "0.10.19",
+        mockito                 : "5.2.0",
+        junit                   : "4.13.2"
 ]
 
 def apt = [
-        autoService      : "com.google.auto.service:auto-service:${versions.autoService}",
-        autoServiceAnnot : "com.google.auto.service:auto-service-annotations:${versions.autoService}",
+        autoService             : "com.google.auto.service:auto-service:${versions.autoService}",
+        autoServiceAnnot        : "com.google.auto.service:auto-service-annotations:${versions.autoService}",
 ]
 
 def build = [

--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -36,14 +36,15 @@ def versions = [
         errorProneApi          : project.hasProperty("epApiVersion") ? epApiVersion : oldestErrorProneApi,
         autoService            : "1.0-rc7",
         javaparser             : "3.26.2",
-        json                   : "1.1.1",
+        gson                   : "2.11.0",
         guava                  : "31.0.1-jre",
         cli                    : "1.5.0",
         commonsio              : "2.11.0",
         progressbar            : "0.9.2",
-        junit                  : "5.7.2",
+        junitjupiter          : "5.7.2",
         nullaway               : "0.10.19",
         mockito                : "5.2.0",
+        junit                  : "4.13.2"
 ]
 
 def apt = [
@@ -53,7 +54,7 @@ def apt = [
 
 def build = [
         guava                   : "com.google.guava:guava:${versions.guava}",
-        json                    : "com.googlecode.json-simple:json-simple:${versions.json}",
+        gson                    : "com.google.code.gson:gson:${versions.gson}",
         progressbar             : "me.tongfei:progressbar:${versions.progressbar}",
         javaparser              : "com.github.javaparser:javaparser-core:${versions.javaparser}",
         commonscli              : "commons-cli:commons-cli:${versions.cli}",
@@ -65,8 +66,9 @@ def build = [
 ]
 
 def test = [
-        junitapi                : "org.junit.jupiter:junit-jupiter-api:${versions.junit}",
-        junitengine             : "org.junit.jupiter:junit-jupiter-engine:${versions.junit}",
+        junitapi                : "org.junit.jupiter:junit-jupiter-api:${versions.junitjupiter}",
+        junitengine             : "org.junit.jupiter:junit-jupiter-engine:${versions.junitjupiter}",
+        junit                   : "junit:junit:${versions.junit}",
         errorProneTestHelpers   : "com.google.errorprone:error_prone_test_helpers:${versions.errorProneApi}",
         mockito                 : "org.mockito:mockito-core:${versions.mockito}"
 ]

--- a/injector/build.gradle
+++ b/injector/build.gradle
@@ -24,15 +24,12 @@
 
 dependencies {
     implementation deps.build.guava
-
     implementation deps.build.javaparser
+    implementation deps.build.gson
+
     testImplementation deps.build.javaparser
-
-    implementation deps.build.json
-
-    implementation deps.build.progressbar
-
     testImplementation deps.build.commonsio
+    testImplementation deps.test.junit
 }
 
 spotless {

--- a/injector/src/main/java/edu/ucr/cs/riple/injector/location/Location.java
+++ b/injector/src/main/java/edu/ucr/cs/riple/injector/location/Location.java
@@ -26,6 +26,7 @@ package edu.ucr.cs.riple.injector.location;
 
 import com.google.common.base.Preconditions;
 import com.google.common.collect.Sets;
+import com.google.gson.JsonObject;
 import edu.ucr.cs.riple.injector.Printer;
 import java.nio.file.Path;
 import java.nio.file.Paths;
@@ -33,7 +34,6 @@ import java.util.Arrays;
 import java.util.Objects;
 import java.util.function.Consumer;
 import javax.annotation.Nullable;
-import org.json.simple.JSONObject;
 
 /** Represents a location of an element in the source code. */
 public abstract class Location {
@@ -68,10 +68,10 @@ public abstract class Location {
    * @param kind The kind of the location.
    * @param json The JSON object containing the path and class values.
    */
-  public Location(LocationKind kind, JSONObject json) {
+  public Location(LocationKind kind, JsonObject json) {
     this.kind = kind;
-    this.clazz = (String) json.get("class");
-    this.path = Paths.get((String) json.get("path"));
+    this.clazz = json.get("class").getAsString();
+    this.path = Paths.get(json.get("path").getAsString());
   }
 
   /**

--- a/injector/src/main/java/edu/ucr/cs/riple/injector/location/LocationToJsonVisitor.java
+++ b/injector/src/main/java/edu/ucr/cs/riple/injector/location/LocationToJsonVisitor.java
@@ -24,8 +24,8 @@
 
 package edu.ucr.cs.riple.injector.location;
 
-import com.google.gson.JsonObject;
 import com.google.gson.JsonArray;
+import com.google.gson.JsonObject;
 
 /** A visitor that converts a location to a JSON object. */
 public class LocationToJsonVisitor implements LocationVisitor<JsonObject, Void> {
@@ -81,7 +81,9 @@ public class LocationToJsonVisitor implements LocationVisitor<JsonObject, Void> 
   @Override
   public JsonObject visitLocalVariable(OnLocalVariable onLocalVariable, Void unused) {
     JsonObject res = defaultAction(onLocalVariable);
-    res.addProperty(KEYS.METHOD.name(), onLocalVariable.encMethod == null ? "" : onLocalVariable.encMethod.method);
+    res.addProperty(
+        KEYS.METHOD.name(),
+        onLocalVariable.encMethod == null ? "" : onLocalVariable.encMethod.method);
     res.addProperty(KEYS.VARIABLES.name(), onLocalVariable.varName);
     return res;
   }

--- a/injector/src/main/java/edu/ucr/cs/riple/injector/location/LocationToJsonVisitor.java
+++ b/injector/src/main/java/edu/ucr/cs/riple/injector/location/LocationToJsonVisitor.java
@@ -24,11 +24,11 @@
 
 package edu.ucr.cs.riple.injector.location;
 
-import org.json.simple.JSONArray;
-import org.json.simple.JSONObject;
+import com.google.gson.JsonObject;
+import com.google.gson.JsonArray;
 
 /** A visitor that converts a location to a JSON object. */
-public class LocationToJsonVisitor implements LocationVisitor<JSONObject, Void> {
+public class LocationToJsonVisitor implements LocationVisitor<JsonObject, Void> {
 
   /** The Keys used to represent a location in JSON format */
   public enum KEYS {
@@ -41,61 +41,55 @@ public class LocationToJsonVisitor implements LocationVisitor<JSONObject, Void> 
     SUPER,
   }
 
-  @SuppressWarnings("unchecked")
-  private JSONObject defaultAction(Location location) {
-    JSONObject res = new JSONObject();
-    res.put(KEYS.CLASS, location.clazz);
-    res.put(KEYS.KIND, location.getKind().toString());
-    res.put(KEYS.PATH, location.path);
-    return res;
-  }
-
-  @SuppressWarnings("unchecked")
-  @Override
-  public JSONObject visitMethod(OnMethod onMethod, Void unused) {
-    JSONObject res = defaultAction(onMethod);
-    res.put(KEYS.METHOD, onMethod.method);
-    return res;
-  }
-
-  @SuppressWarnings("unchecked")
-  @Override
-  public JSONObject visitField(OnField onField, Void unused) {
-    JSONObject res = defaultAction(onField);
-    JSONArray fields = new JSONArray();
-    fields.addAll(onField.variables);
-    res.put(KEYS.VARIABLES, fields);
-    return res;
-  }
-
-  @SuppressWarnings("unchecked")
-  @Override
-  public JSONObject visitParameter(OnParameter onParameter, Void unused) {
-    JSONObject res = defaultAction(onParameter);
-    res.put(KEYS.METHOD, onParameter.enclosingMethod.method);
-    res.put(KEYS.INDEX, onParameter.index);
+  private JsonObject defaultAction(Location location) {
+    JsonObject res = new JsonObject();
+    res.addProperty(KEYS.CLASS.name(), location.clazz);
+    res.addProperty(KEYS.KIND.name(), location.getKind().toString());
+    res.addProperty(KEYS.PATH.name(), location.path.toString());
     return res;
   }
 
   @Override
-  public JSONObject visitClass(OnClass onClass, Void unused) {
+  public JsonObject visitMethod(OnMethod onMethod, Void unused) {
+    JsonObject res = defaultAction(onMethod);
+    res.addProperty(KEYS.METHOD.name(), onMethod.method);
+    return res;
+  }
+
+  @Override
+  public JsonObject visitField(OnField onField, Void unused) {
+    JsonObject res = defaultAction(onField);
+    JsonArray fields = new JsonArray();
+    onField.variables.forEach(fields::add);
+    res.add(KEYS.VARIABLES.name(), fields);
+    return res;
+  }
+
+  @Override
+  public JsonObject visitParameter(OnParameter onParameter, Void unused) {
+    JsonObject res = defaultAction(onParameter);
+    res.addProperty(KEYS.METHOD.name(), onParameter.enclosingMethod.method);
+    res.addProperty(KEYS.INDEX.name(), onParameter.index);
+    return res;
+  }
+
+  @Override
+  public JsonObject visitClass(OnClass onClass, Void unused) {
     return defaultAction(onClass);
   }
 
-  @SuppressWarnings("unchecked")
   @Override
-  public JSONObject visitLocalVariable(OnLocalVariable onLocalVariable, Void unused) {
-    JSONObject res = defaultAction(onLocalVariable);
-    res.put(KEYS.METHOD, onLocalVariable.encMethod == null ? "" : onLocalVariable.encMethod.method);
-    res.put(KEYS.VARIABLES, onLocalVariable.varName);
+  public JsonObject visitLocalVariable(OnLocalVariable onLocalVariable, Void unused) {
+    JsonObject res = defaultAction(onLocalVariable);
+    res.addProperty(KEYS.METHOD.name(), onLocalVariable.encMethod == null ? "" : onLocalVariable.encMethod.method);
+    res.addProperty(KEYS.VARIABLES.name(), onLocalVariable.varName);
     return res;
   }
 
-  @SuppressWarnings("unchecked")
   @Override
-  public JSONObject visitClassDeclaration(OnClassDeclaration onClassDeclaration, Void unused) {
-    JSONObject res = defaultAction(onClassDeclaration);
-    res.put(KEYS.SUPER, onClassDeclaration.target);
+  public JsonObject visitClassDeclaration(OnClassDeclaration onClassDeclaration, Void unused) {
+    JsonObject res = defaultAction(onClassDeclaration);
+    res.addProperty(KEYS.SUPER.name(), onClassDeclaration.target);
     return res;
   }
 }

--- a/injector/src/main/java/edu/ucr/cs/riple/injector/location/OnClassDeclaration.java
+++ b/injector/src/main/java/edu/ucr/cs/riple/injector/location/OnClassDeclaration.java
@@ -24,9 +24,9 @@
 
 package edu.ucr.cs.riple.injector.location;
 
+import com.google.gson.JsonObject;
 import edu.ucr.cs.riple.injector.Printer;
 import java.nio.file.Path;
-import org.json.simple.JSONObject;
 
 public class OnClassDeclaration extends Location {
 
@@ -42,9 +42,9 @@ public class OnClassDeclaration extends Location {
     this.target = target;
   }
 
-  public OnClassDeclaration(JSONObject json) {
+  public OnClassDeclaration(JsonObject json) {
     super(LocationKind.CLASS_DECL, json);
-    this.target = (String) json.get("target");
+    this.target = json.get("target").getAsString();
   }
 
   @Override


### PR DESCRIPTION
This PR updates the project's JSON handling dependency from `json-simple` to `GSON`. The switch to `GSON` addresses the need to suppress unchecked warnings (`@SuppressWarnings("unchecked")`) that were frequently required with `json-simple`. This change is also a proactive step in preparation for upcoming updates involving automatic source code fixes, which will heavily rely on JSON deserialization and parsing APIs, particularly for handling network connections and response parsing.