### PR TITLE
Use TypeUse Annotations for Jspecify and Checkers frameworks

### DIFF
--- a/annotator-core/src/main/java/edu/ucr/cs/riple/core/checkers/nullaway/NullAway.java
+++ b/annotator-core/src/main/java/edu/ucr/cs/riple/core/checkers/nullaway/NullAway.java
@@ -39,6 +39,7 @@ import edu.ucr.cs.riple.injector.Printer;
 import edu.ucr.cs.riple.injector.changes.AddAnnotation;
 import edu.ucr.cs.riple.injector.changes.AddMarkerAnnotation;
 import edu.ucr.cs.riple.injector.changes.AddSingleElementAnnotation;
+import edu.ucr.cs.riple.injector.changes.AddTypeUseMarkerAnnotation;
 import edu.ucr.cs.riple.injector.location.Location;
 import edu.ucr.cs.riple.injector.location.OnField;
 import edu.ucr.cs.riple.injector.location.OnParameter;
@@ -129,10 +130,15 @@ public class NullAway extends CheckerBaseClass<NullAwayError> {
     if (nonnullTarget != null && nonnullTarget.isOnField()) {
       nonnullTarget = extendVariableList(nonnullTarget.toField(), moduleInfo);
     }
-    Set<AddAnnotation> annotations =
-        nonnullTarget == null
-            ? Set.of()
-            : Set.of(new AddMarkerAnnotation(nonnullTarget, config.nullableAnnot));
+    Set<AddAnnotation> annotations;
+    if (nonnullTarget == null) {
+      annotations = Set.of();
+    } else if (Utility.isTypeUseAnnotation(config.nullableAnnot)) {
+      annotations = Set.of(new AddTypeUseMarkerAnnotation(nonnullTarget, config.nullableAnnot));
+    } else {
+      annotations = Set.of(new AddMarkerAnnotation(nonnullTarget, config.nullableAnnot));
+    }
+
     return createError(
         errorType,
         errorMessage,

--- a/annotator-core/src/main/java/edu/ucr/cs/riple/core/util/Utility.java
+++ b/annotator-core/src/main/java/edu/ucr/cs/riple/core/util/Utility.java
@@ -303,4 +303,15 @@ public class Utility {
       throw new RuntimeException("Exception while reading file: " + path, e);
     }
   }
+
+  /**
+   * Check whether an annotation is a type-use annotation.
+   *
+   * @param annotName annotation name
+   * @return true if we annotName is a type-use annotation, false otherwise
+   */
+  public static boolean isTypeUseAnnotation(String annotName) {
+    return annotName.contains(".jspecify.annotations.Nullable")
+        || annotName.contains(".checkerframework.checker.nullness.qual.Nullable");
+  }
 }


### PR DESCRIPTION
This PR updates the Nullaway Annotator to treat nullable annotations from the `checkers `and `jspecify` frameworks as type-use annotations. This change helps to align with the expected behavior of these frameworks.