### PR TITLE
Fix issue with adding/removing type use annotations on array component type.

### DIFF
--- a/injector/src/main/java/edu/ucr/cs/riple/injector/changes/TypeArgumentChangeVisitor.java
+++ b/injector/src/main/java/edu/ucr/cs/riple/injector/changes/TypeArgumentChangeVisitor.java
@@ -106,12 +106,9 @@ public class TypeArgumentChangeVisitor
     if (isAtBase()) {
       return applyOnType(type, change);
     }
-    // if current index is 1, the process component type
-    if (!index.isEmpty()) {
-      boolean onComponentType = index.pollFirst() == 1;
-      if (onComponentType) {
-        return type.getComponentType().accept(this, change);
-      }
+    if (!index.isEmpty() && index.pollFirst() == 1) {
+      // current index is 1, we need to visit the component type.
+      return type.getComponentType().accept(this, change);
     }
     return Collections.emptySet();
   }

--- a/injector/src/test/java/edu/ucr/cs/riple/injector/TypeUseAnnotationTest.java
+++ b/injector/src/test/java/edu/ucr/cs/riple/injector/TypeUseAnnotationTest.java
@@ -955,4 +955,148 @@ public class TypeUseAnnotationTest extends BaseInjectorTest {
                 "custom.example.RUntainted"))
         .start();
   }
+
+  @Test
+  public void arrayComprehensiveAdditionTest() {
+    injectorTestHelper
+        .addInput(
+            "Foo.java",
+            "package test;",
+            "import javax.annotation.Nullable;",
+            "public class Foo {",
+            "   Object [] h1 = new Object[4];",
+            "   Object [] h2 = new Object[4];",
+            "   List<Object[]> h3;",
+            "   List<Object[]> h4;",
+            "   List<Object>[] h5;",
+            "   List<Object>[] h6;",
+            "   List<Object>[] h7;",
+            "   List<Object[]>[] h8;",
+            "   List<Object[]>[] h9;",
+            "}")
+        .expectOutput(
+            "package test;",
+            "import javax.annotation.Nullable;",
+            "public class Foo {",
+            "   @Nullable Object [] h1 = new Object[4];",
+            "   Object @Nullable [] h2 = new Object[4];",
+            "   List<@Nullable Object[]> h3;",
+            "   List<Object@Nullable []> h4;",
+            "   @Nullable List<Object>[] h5;",
+            "   List<@Nullable Object>[] h6;",
+            "   List<Object>@Nullable [] h7;",
+            "   List<Object@Nullable []>[] h8;",
+            "   List<@Nullable Object[]>[] h9;",
+            "}")
+        .addChanges(
+            new AddTypeUseMarkerAnnotation(
+                new OnField("Foo.java", "test.Foo", Set.of("h1")),
+                "javax.annotation.Nullable",
+                ImmutableList.of(ImmutableList.of(1, 0))),
+            new AddTypeUseMarkerAnnotation(
+                new OnField("Foo.java", "test.Foo", Set.of("h2")),
+                "javax.annotation.Nullable",
+                ImmutableList.of(ImmutableList.of(0))),
+            new AddTypeUseMarkerAnnotation(
+                new OnField("Foo.java", "test.Foo", Set.of("h3")),
+                "javax.annotation.Nullable",
+                ImmutableList.of(ImmutableList.of(1, 1, 0))),
+            new AddTypeUseMarkerAnnotation(
+                new OnField("Foo.java", "test.Foo", Set.of("h4")),
+                "javax.annotation.Nullable",
+                ImmutableList.of(ImmutableList.of(1, 0))),
+            new AddTypeUseMarkerAnnotation(
+                new OnField("Foo.java", "test.Foo", Set.of("h5")),
+                "javax.annotation.Nullable",
+                ImmutableList.of(ImmutableList.of(1, 0))),
+            new AddTypeUseMarkerAnnotation(
+                new OnField("Foo.java", "test.Foo", Set.of("h6")),
+                "javax.annotation.Nullable",
+                ImmutableList.of(ImmutableList.of(1, 1, 0))),
+            new AddTypeUseMarkerAnnotation(
+                new OnField("Foo.java", "test.Foo", Set.of("h7")),
+                "javax.annotation.Nullable",
+                ImmutableList.of(ImmutableList.of(0))),
+            new AddTypeUseMarkerAnnotation(
+                new OnField("Foo.java", "test.Foo", Set.of("h8")),
+                "javax.annotation.Nullable",
+                ImmutableList.of(ImmutableList.of(1, 1, 0))),
+            new AddTypeUseMarkerAnnotation(
+                new OnField("Foo.java", "test.Foo", Set.of("h9")),
+                "javax.annotation.Nullable",
+                ImmutableList.of(ImmutableList.of(1, 1, 1, 0))))
+        .start();
+  }
+
+  @Test
+  public void arrayComprehensiveDeletionTest() {
+    injectorTestHelper
+        .addInput(
+            "Foo.java",
+            "package test;",
+            "import javax.annotation.Nullable;",
+            "public class Foo {",
+            "   @Nullable Object [] h1 = new Object[4];",
+            "   Object @Nullable [] h2 = new Object[4];",
+            "   List<@Nullable Object[]> h3;",
+            "   List<Object@Nullable []> h4;",
+            "   @Nullable List<Object>[] h5;",
+            "   List<@Nullable Object>[] h6;",
+            "   List<Object>@Nullable [] h7;",
+            "   List<Object@Nullable []>[] h8;",
+            "   List<@Nullable Object[]>[] h9;",
+            "}")
+        .expectOutput(
+            "package test;",
+            "import javax.annotation.Nullable;",
+            "public class Foo {",
+            "   Object [] h1 = new Object[4];",
+            "   Object [] h2 = new Object[4];",
+            "   List<Object[]> h3;",
+            "   List<Object[]> h4;",
+            "   List<Object>[] h5;",
+            "   List<Object>[] h6;",
+            "   List<Object>[] h7;",
+            "   List<Object[]>[] h8;",
+            "   List<Object[]>[] h9;",
+            "}")
+        .addChanges(
+            new RemoveTypeUseMarkerAnnotation(
+                new OnField("Foo.java", "test.Foo", Set.of("h1")),
+                "javax.annotation.Nullable",
+                ImmutableList.of(ImmutableList.of(1, 0))),
+            new RemoveTypeUseMarkerAnnotation(
+                new OnField("Foo.java", "test.Foo", Set.of("h2")),
+                "javax.annotation.Nullable",
+                ImmutableList.of(ImmutableList.of(0))),
+            new RemoveTypeUseMarkerAnnotation(
+                new OnField("Foo.java", "test.Foo", Set.of("h3")),
+                "javax.annotation.Nullable",
+                ImmutableList.of(ImmutableList.of(1, 1, 0))),
+            new RemoveTypeUseMarkerAnnotation(
+                new OnField("Foo.java", "test.Foo", Set.of("h4")),
+                "javax.annotation.Nullable",
+                ImmutableList.of(ImmutableList.of(1, 0))),
+            new RemoveTypeUseMarkerAnnotation(
+                new OnField("Foo.java", "test.Foo", Set.of("h5")),
+                "javax.annotation.Nullable",
+                ImmutableList.of(ImmutableList.of(1, 0))),
+            new RemoveTypeUseMarkerAnnotation(
+                new OnField("Foo.java", "test.Foo", Set.of("h6")),
+                "javax.annotation.Nullable",
+                ImmutableList.of(ImmutableList.of(1, 1, 0))),
+            new RemoveTypeUseMarkerAnnotation(
+                new OnField("Foo.java", "test.Foo", Set.of("h7")),
+                "javax.annotation.Nullable",
+                ImmutableList.of(ImmutableList.of(0))),
+            new RemoveTypeUseMarkerAnnotation(
+                new OnField("Foo.java", "test.Foo", Set.of("h8")),
+                "javax.annotation.Nullable",
+                ImmutableList.of(ImmutableList.of(1, 1, 0))),
+            new RemoveTypeUseMarkerAnnotation(
+                new OnField("Foo.java", "test.Foo", Set.of("h9")),
+                "javax.annotation.Nullable",
+                ImmutableList.of(ImmutableList.of(1, 1, 1, 0))))
+        .start();
+  }
 }


### PR DESCRIPTION
With the new specification for @Nullable type-use annotations, the correct placement for annotating the component type of an array is as follows:
```java
@Nullable Object arr[]
```
However, when parsing this expression, Javaparser associates the annotation with the entire `Object[] arr` node rather than the intended component type `@Nullable Object`.

This PR addresses this issue by adding a workaround ensuring correct annotation placement and includes a comprehensive set of tests to validate the fix.