### PR TITLE
Remove NullAway supported serialization version hardcoded values.

### DIFF
--- a/annotator-core/src/main/java/edu/ucr/cs/riple/core/checkers/nullaway/NullAway.java
+++ b/annotator-core/src/main/java/edu/ucr/cs/riple/core/checkers/nullaway/NullAway.java
@@ -107,8 +107,9 @@ public class NullAway extends CheckerBaseClass<NullAwayError> {
     String[] values = line.split("\t");
     Preconditions.checkArgument(
         values.length == 12,
-        "Expected 12 values to create Error instance in NullAway serialization version 2 but found: "
-            + values.length);
+        String.format(
+            "Expected 12 values to create Error instance in NullAway serialization version %s but found: %s",
+            NullAway.VERSION, values.length));
     int offset = Integer.parseInt(values[4]);
     Path path = Printer.deserializePath(values[5]);
     String errorMessage = values[1];

--- a/annotator-core/src/test/java/edu/ucr/cs/riple/core/tools/Utility.java
+++ b/annotator-core/src/test/java/edu/ucr/cs/riple/core/tools/Utility.java
@@ -24,6 +24,7 @@
 
 package edu.ucr.cs.riple.core.tools;
 
+import edu.ucr.cs.riple.core.checkers.nullaway.NullAway;
 import edu.ucr.cs.riple.scanner.Serializer;
 import java.io.BufferedReader;
 import java.io.IOException;
@@ -161,7 +162,8 @@ public class Utility {
                             createAFileWithContent(
                                 testDir.resolve("0").resolve(fileName), "HEADER\n"));
                 createAFileWithContent(
-                    testDir.resolve("0").resolve("serialization_version.txt"), "3");
+                    testDir.resolve("0").resolve("serialization_version.txt"),
+                    String.valueOf(NullAway.VERSION));
                 return null;
               });
       runnable.run();


### PR DESCRIPTION
This PR updates two occurrences where hardcoded serialization version values were used for NullAway support. Instead of using fixed values, the code now references the corresponding variable (`NullAway.VERSION`), improving maintainability.