### PR TITLE
Support local variable arrays

### DIFF
--- a/annotator-core/build.gradle
+++ b/annotator-core/build.gradle
@@ -57,7 +57,7 @@ spotless {
 }
 
 // Should be the latest supporting version of NullAway.
-def NULLAWAY_TEST = "0.12.3"
+def NULLAWAY_TEST = "0.12.4-SNAPSHOT"
 
 tasks.test.dependsOn(':annotator-scanner:publishToMavenLocal')
 

--- a/annotator-core/build.gradle
+++ b/annotator-core/build.gradle
@@ -57,7 +57,7 @@ spotless {
 }
 
 // Should be the latest supporting version of NullAway.
-def NULLAWAY_TEST = "0.12.4-SNAPSHOT"
+def NULLAWAY_TEST = "0.12.4"
 
 tasks.test.dependsOn(':annotator-scanner:publishToMavenLocal')
 

--- a/annotator-core/src/test/java/edu/ucr/cs/riple/core/CoreTest.java
+++ b/annotator-core/src/test/java/edu/ucr/cs/riple/core/CoreTest.java
@@ -30,6 +30,7 @@ import static java.util.Collections.singleton;
 import com.google.common.collect.ImmutableList;
 import edu.ucr.cs.riple.core.tools.TReport;
 import edu.ucr.cs.riple.injector.location.OnField;
+import edu.ucr.cs.riple.injector.location.OnLocalVariable;
 import edu.ucr.cs.riple.injector.location.OnMethod;
 import edu.ucr.cs.riple.injector.location.OnParameter;
 import java.util.Collections;
@@ -594,6 +595,30 @@ public class CoreTest extends AnnotatorBaseCoreTest {
                 -1))
         .disableBailOut()
         .checkExpectedOutput("assignNullableToNonnullArrayComponentTypeTest/expected")
+        .enableJSpecifyMode()
+        .start();
+  }
+
+  @Test
+  public void assignNullableToNonnullArrayComponentTypeLocalVariableTest() {
+    coreTestHelper
+        .onTarget()
+        .withSourceLines(
+            "Main.java",
+            "package test;",
+            "public class Main {",
+            "   void run() {",
+            "     Object[] arr = new Object[1];",
+            "     arr[0] = null;",
+            "   }",
+            "}")
+        .withExpectedReports(
+            new TReport(
+                new OnLocalVariable("Main.java", "test.Main", "run()", "arr"),
+                ImmutableList.of(ImmutableList.of(1, 0)),
+                -1))
+        .disableBailOut()
+        .checkExpectedOutput("assignNullableToNonnullArrayComponentTypeLocalVariableTest/expected")
         .enableJSpecifyMode()
         .start();
   }

--- a/annotator-core/src/test/resources/assignNullableToNonnullArrayComponentTypeLocalVariableTest/expected/Target/src/main/java/test/Main.java
+++ b/annotator-core/src/test/resources/assignNullableToNonnullArrayComponentTypeLocalVariableTest/expected/Target/src/main/java/test/Main.java
@@ -1,0 +1,8 @@
+package test;
+import org.jspecify.annotations.Nullable;
+public class Main {
+   void run() {
+     @Nullable Object[] arr = new Object[1];
+     arr[0] = null;
+   }
+}

--- a/injector/src/main/java/edu/ucr/cs/riple/injector/location/Location.java
+++ b/injector/src/main/java/edu/ucr/cs/riple/injector/location/Location.java
@@ -111,6 +111,8 @@ public abstract class Location {
         return new OnMethod(path, clazz, values[2]);
       case PARAMETER:
         return new OnParameter(path, clazz, values[2], Integer.parseInt(values[4]));
+      case LOCAL_VARIABLE:
+        return new OnLocalVariable(path, clazz, values[2], values[3]);
       default:
         throw new RuntimeException(
             "Cannot reach this statement, values: " + Arrays.toString(values));


### PR DESCRIPTION
This PR enables the annotator to deserialize errors from Nullaway that have Local Variable LocationKind. This helps to correctly annotate arrays that are declared as local variables.