### PR TITLE
Accept every language level the bundled parser supports

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -112,4 +112,18 @@ jobs:
           ANNOTATOR_TEST_DISABLE_PARALLEL_PROCESSING: "false"
           ANNOTATOR_TEST_DISABLE_CACHING: "false"
         run: ./gradlew :annotator-core:test --tests "edu.ucr.cs.riple.core.Java21Test"
+  parser-configuration-25:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Set up JDK 25
+        uses: actions/setup-java@v4
+        with:
+          java-version: 25
+          distribution: 'temurin'
+      - name: Build with Gradle
+        env:
+          ANNOTATOR_TEST_DISABLE_PARALLEL_PROCESSING: "false"
+          ANNOTATOR_TEST_DISABLE_CACHING: "false"
+        run: ./gradlew :annotator-core:test --tests "edu.ucr.cs.riple.core.Java25Test"
 

--- a/OPTIONS.md
+++ b/OPTIONS.md
@@ -20,4 +20,4 @@ Here are all __optional__ arguments that can alter Annotator's default configura
 | `-drdl, --deactivate-region-detection-lombok`          | Deactivates region detection for Lombok. |
 | `-nna, --nonnull-annotations <arg>`                    | Adds a list of non-null annotations separated by a comma to be acknowledged by Annotator (e.g., com.example1.Nonnull,com.example2.Nonnull) |
 | `eic, enable-impact-cache`                             | Enables fixes impacts caching for next cycles. |
-| `-ll, --language-level <arg>`                          | Java language level used by the parser when reading source files. Supported values: `11`, `17`, `21`. Defaults to `17`. Use `21` when the target project uses Java 21 features such as record patterns or switch pattern matching. |
+| `-ll, --language-level <arg>`                          | Java language level used by the parser when reading source files. Accepts any release the bundled parser supports (`11` … `26`). Defaults to `17`. Set it to the release the target project compiles with, otherwise its syntax fails to parse — e.g. record and switch patterns need `21`, unnamed variables (`_`) need `22`. |

--- a/README.md
+++ b/README.md
@@ -182,7 +182,7 @@ Here are some useful __optional__ arguments that can alter the default configura
 |--------------------------------------------------------|-------------|
 | `-n,--nullable <arg>`                                  | Sets custom `@Nullable` annotation. |
 | `-rboserr, --redirect-build-output-stderr`             | Redirects build outputs to `STD Err`. |
-| `-ll, --language-level <arg>`                          | Parser language level. Supported values: `11`, `17`, `21`. Defaults to `17`. Required when the target project uses Java 21 syntax (e.g. record patterns, switch patterns). |
+| `-ll, --language-level <arg>`                          | Parser language level. Accepts any release the bundled parser supports (`11` … `26`). Defaults to `17`. Set it to the release the target project compiles with, otherwise its syntax fails to parse. |
 
 
 To learn more about all the __optional__ arguments, please refer to [OPTIONS.md](./OPTIONS.md)

--- a/annotator-core/build.gradle
+++ b/annotator-core/build.gradle
@@ -98,6 +98,15 @@ if (!JavaVersion.current().isCompatibleWith(JavaVersion.VERSION_21)) {
     }
 }
 
+// Java25Test builds a target project with language features released after Java 21.
+if (!JavaVersion.current().isCompatibleWith(JavaVersion.VERSION_25)) {
+    test {
+        filter {
+            excludeTestsMatching "edu.ucr.cs.riple.core.Java25Test"
+        }
+    }
+}
+
 // temporarily exclude LombokTest until we find a solution for the issue.
 test {
     filter {

--- a/annotator-core/src/main/java/edu/ucr/cs/riple/core/Config.java
+++ b/annotator-core/src/main/java/edu/ucr/cs/riple/core/Config.java
@@ -25,6 +25,7 @@
 package edu.ucr.cs.riple.core;
 
 import com.github.javaparser.ParserConfiguration;
+import com.google.common.base.Enums;
 import com.google.common.base.Preconditions;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Sets;
@@ -378,7 +379,7 @@ public class Config {
             "ll",
             "language-level",
             true,
-            "Java language level to use when parsing code. Supported values are 11, 17 and 21.  Defaults to 17.");
+            "Java language level to use when parsing code. Accepts any release supported by the bundled parser, e.g. 11, 17, 21, 25. Defaults to 17.");
     languageLevelOption.setRequired(false);
     options.addOption(languageLevelOption);
 
@@ -491,22 +492,20 @@ public class Config {
   }
 
   /**
-   * Gets the language level from the string representation. "11" for Java 11 and "17" for Java 17.
+   * Gets the language level from the string representation, e.g. "17" for Java 17. Accepts every
+   * release the bundled parser knows, so a target project on a current JDK can be read as-is.
    *
    * @param languageLevelString string representation of the language level.
    * @return the language level.
    */
   private ParserConfiguration.LanguageLevel getLanguageLevel(String languageLevelString) {
-    switch (languageLevelString) {
-      case "11":
-        return ParserConfiguration.LanguageLevel.JAVA_11;
-      case "17":
-        return ParserConfiguration.LanguageLevel.JAVA_17;
-      case "21":
-        return ParserConfiguration.LanguageLevel.JAVA_21;
-      default:
-        throw new IllegalArgumentException("Unsupported language level: " + languageLevelString);
-    }
+    return Enums.getIfPresent(
+            ParserConfiguration.LanguageLevel.class, "JAVA_" + languageLevelString)
+        .toJavaUtil()
+        .orElseThrow(
+            () ->
+                new IllegalArgumentException(
+                    "Unsupported language level: " + languageLevelString));
   }
 
   /**

--- a/annotator-core/src/main/java/edu/ucr/cs/riple/core/Config.java
+++ b/annotator-core/src/main/java/edu/ucr/cs/riple/core/Config.java
@@ -179,6 +179,12 @@ public class Config {
   public final ParserConfiguration.LanguageLevel languageLevel;
 
   /**
+   * Prefix shared by every {@link ParserConfiguration.LanguageLevel} constant, stripped from the
+   * serialized form and prepended back when reading it.
+   */
+  private static final String LANGUAGE_LEVEL_PREFIX = "JAVA_";
+
+  /**
    * Builds context from command line arguments.
    *
    * @param args arguments.
@@ -498,14 +504,24 @@ public class Config {
    * @param languageLevelString string representation of the language level.
    * @return the language level.
    */
-  private ParserConfiguration.LanguageLevel getLanguageLevel(String languageLevelString) {
+  private static ParserConfiguration.LanguageLevel getLanguageLevel(String languageLevelString) {
     return Enums.getIfPresent(
-            ParserConfiguration.LanguageLevel.class, "JAVA_" + languageLevelString)
+            ParserConfiguration.LanguageLevel.class, LANGUAGE_LEVEL_PREFIX + languageLevelString)
         .toJavaUtil()
         .orElseThrow(
             () ->
-                new IllegalArgumentException(
-                    "Unsupported language level: " + languageLevelString));
+                new IllegalArgumentException("Unsupported language level: " + languageLevelString));
+  }
+
+  /**
+   * Gets the string representation of the language level, the inverse of {@link
+   * #getLanguageLevel(String)}.
+   *
+   * @param languageLevel the language level.
+   * @return string representation of the language level.
+   */
+  private static String getLanguageLevelString(ParserConfiguration.LanguageLevel languageLevel) {
+    return languageLevel.name().substring(LANGUAGE_LEVEL_PREFIX.length());
   }
 
   /**
@@ -692,7 +708,7 @@ public class Config {
       json.addProperty("REDIRECT_BUILD_OUTPUT_TO_STDERR", redirectBuildOutputToStdErr);
       json.addProperty("SUPPRESS_REMAINING_ERRORS", suppressRemainingErrors);
       json.addProperty("INFERENCE_ACTIVATION", inferenceActivated);
-      json.addProperty("LANGUAGE_LEVEL", languageLevel.name().split("_")[1]);
+      json.addProperty("LANGUAGE_LEVEL", getLanguageLevelString(languageLevel));
       JsonArray configPathsJson = new JsonArray();
       configPaths.forEach(
           info -> {

--- a/annotator-core/src/test/java/edu/ucr/cs/riple/core/ConfigurationTest.java
+++ b/annotator-core/src/test/java/edu/ucr/cs/riple/core/ConfigurationTest.java
@@ -30,10 +30,12 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
+import com.github.javaparser.ParserConfiguration;
 import com.github.javaparser.utils.Pair;
 import com.google.common.collect.ImmutableSet;
 import edu.ucr.cs.riple.core.checkers.nullaway.FixSerializationConfig;
 import edu.ucr.cs.riple.core.checkers.nullaway.NullAway;
+import edu.ucr.cs.riple.core.module.ModuleConfiguration;
 import edu.ucr.cs.riple.scanner.ScannerConfigWriter;
 import java.io.FileOutputStream;
 import java.io.IOException;
@@ -274,6 +276,58 @@ public class ConfigurationTest {
           assertTrue(config.suppressRemainingErrors);
           assertEquals(config.nullUnMarkedAnnotation, "edu.ucr.example.NullUnmarked");
         });
+  }
+
+  @Test
+  public void testLanguageLevelFlag() {
+    runTestWithMockedBuild(
+        testDir,
+        () -> {
+          // Defaults to Java 17 when the flag is not present.
+          assertEquals(
+              ParserConfiguration.LanguageLevel.JAVA_17,
+              makeConfigWithFlags(requiredFlagsCli).languageLevel);
+
+          Map<String, ParserConfiguration.LanguageLevel> levels =
+              Map.of(
+                  "11", ParserConfiguration.LanguageLevel.JAVA_11,
+                  "21", ParserConfiguration.LanguageLevel.JAVA_21,
+                  "25", ParserConfiguration.LanguageLevel.JAVA_25,
+                  "17_PREVIEW", ParserConfiguration.LanguageLevel.JAVA_17_PREVIEW);
+          levels.forEach(
+              (flagValue, expectedLevel) -> {
+                List<CLIFlag> flags = new ArrayList<>(requiredFlagsCli);
+                flags.add(new CLIFlagWithValue("ll", flagValue));
+                assertEquals(expectedLevel, makeConfigWithFlags(flags).languageLevel);
+              });
+
+          List<CLIFlag> unknownLevelFlags = new ArrayList<>(requiredFlagsCli);
+          unknownLevelFlags.add(new CLIFlagWithValue("ll", "1000"));
+          IllegalArgumentException ex =
+              assertThrows(
+                  IllegalArgumentException.class, () -> makeConfigWithFlags(unknownLevelFlags));
+          assertTrue(ex.getMessage().contains("Unsupported language level: 1000"));
+        });
+  }
+
+  @Test
+  public void testLanguageLevelSurvivesSerialization() {
+    Path configPath = testDir.resolve("config.json");
+    Config.Builder builder = new Config.Builder();
+    builder.buildCommand = "./gradlew compileJava";
+    builder.initializerAnnotation = "edu.ucr.Initializer";
+    builder.nullableAnnotation = "javax.annotation.Nullable";
+    builder.outputDir = testDir.toString();
+    builder.checker = NullAway.NAME;
+    builder.configPaths =
+        List.of(
+            new ModuleConfiguration(
+                0, testDir, testDir.resolve("nullaway.xml"), testDir.resolve("scanner.xml")));
+    for (ParserConfiguration.LanguageLevel level : ParserConfiguration.LanguageLevel.values()) {
+      builder.languageLevel = level;
+      builder.write(configPath);
+      assertEquals(level, new Config(configPath).languageLevel);
+    }
   }
 
   /**

--- a/annotator-core/src/test/java/edu/ucr/cs/riple/core/Java25Test.java
+++ b/annotator-core/src/test/java/edu/ucr/cs/riple/core/Java25Test.java
@@ -1,0 +1,84 @@
+/*
+ * MIT License
+ *
+ * Copyright (c) 2026 Nima Karimipour
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+package edu.ucr.cs.riple.core;
+
+import com.github.javaparser.ParserConfiguration;
+import edu.ucr.cs.riple.core.tools.TReport;
+import edu.ucr.cs.riple.injector.location.OnField;
+import java.util.Set;
+import org.junit.Test;
+
+/**
+ * Tests in this class are related to language levels released after Java 21. These tests include
+ * blocks of code that are not syntactically supported by Java 21.
+ */
+public class Java25Test extends AnnotatorBaseCoreTest {
+
+  public Java25Test() {
+    super("java-25");
+  }
+
+  @Test
+  public void moduleImportDeclarationTest() {
+    coreTestHelper
+        .onTarget()
+        .withSourceLines(
+            "Main.java",
+            "package test;",
+            "// module import declaration - finalized in Java 25 (JEP 511)",
+            "import module java.base;",
+            "public class Main {",
+            "   Object f1, f2, f3, f4;",
+            "   List<String> foo() {",
+            "      return List.of();",
+            "   }",
+            "}")
+        .withExpectedReports(
+            new TReport(new OnField("Main.java", "test.Main", Set.of("f1", "f2", "f3", "f4")), -4))
+        .withLanguageLevel(ParserConfiguration.LanguageLevel.JAVA_25)
+        .start();
+  }
+
+  @Test
+  public void unnamedVariableTest() {
+    coreTestHelper
+        .onTarget()
+        .withSourceLines(
+            "Main.java",
+            "package test;",
+            "import java.util.List;",
+            "public class Main {",
+            "   Object f1, f2, f3, f4;",
+            "   void foo(List<String> items) {",
+            "      // unnamed variable - finalized in Java 22 (JEP 456)",
+            "      for (String _ : items) { }",
+            "   }",
+            "}")
+        .withExpectedReports(
+            new TReport(new OnField("Main.java", "test.Main", Set.of("f1", "f2", "f3", "f4")), -4))
+        .withLanguageLevel(ParserConfiguration.LanguageLevel.JAVA_25)
+        .start();
+  }
+}

--- a/annotator-core/src/test/resources/templates/java-25/build.gradle
+++ b/annotator-core/src/test/resources/templates/java-25/build.gradle
@@ -1,0 +1,85 @@
+/*
+ * MIT License
+ *
+ * Copyright (c) 2026 Nima Karimipour
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+import net.ltgt.gradle.errorprone.CheckSeverity
+
+plugins{
+    id "net.ltgt.errorprone" version "5.1.0" apply false
+}
+
+subprojects {
+    apply plugin: "java"
+    apply plugin: "net.ltgt.errorprone"
+
+    repositories {
+        mavenLocal()
+        mavenCentral()
+        google()
+    }
+
+    def libraryloader = project.getProperty("library-model-loader-path")
+
+    repositories {
+        mavenLocal()
+        mavenCentral()
+    }
+
+    dependencies {
+        if(project.name != "Target"){
+            compileOnly project(":Target")
+            annotationProcessor files(libraryloader)
+        }
+        annotationProcessor "com.uber.nullaway:nullaway:" + System.getenv('NULLAWAY_TEST_VERSION')
+        annotationProcessor "edu.ucr.cs.riple.annotator:annotator-scanner:" + System.getenv('ANNOTATOR_VERSION')
+
+        // to add @Initializer
+        compileOnly "com.uber.nullaway:nullaway-annotations:" + System.getenv('NULLAWAY_TEST_VERSION')
+        // to add jetbrains annotations (testing type use vs type declaration)
+        compileOnly 'org.jetbrains:annotations:24.0.0'
+        compileOnly "org.jspecify:jspecify:0.3.0"
+        compileOnly "com.google.code.findbugs:jsr305:3.0.2"
+        errorprone "com.google.errorprone:error_prone_core:" + System.getenv('ERROR_PRONE_TEST_VERSION')
+    }
+
+    tasks.withType(JavaCompile) {
+        // remove the if condition if you want to run NullAway on test code
+        if (!name.toLowerCase().contains("test")) {
+            options.errorprone.disableAllChecks = true
+            options.errorprone.disableAllWarnings = true
+            options.errorprone {
+                check("NullAway", CheckSeverity.WARN)
+                check("AnnotatorScanner", CheckSeverity.WARN)
+                option("NullAway:AnnotatedPackages", "test")
+                option("NullAway:SerializeFixMetadata", "true")
+                option("NullAway:FixSerializationConfigPath", project.getProperty(project.name + "-nullaway-config-path"))
+                option("NullAway:AcknowledgeLibraryModelsOfAnnotatedCode", "true")
+                option("NullAway:JSpecifyMode", project.getProperty("jspecify"))
+                option("AnnotatorScanner:ConfigPath", project.getProperty(project.name + "-scanner-config-path"))
+            }
+        }
+        options.compilerArgs << "-Xmaxerrs" << "100000"
+        options.compilerArgs << "-Xmaxwarns" << "100000"
+        options.fork = true
+    }
+}

--- a/annotator-core/src/test/resources/templates/java-25/settings.gradle
+++ b/annotator-core/src/test/resources/templates/java-25/settings.gradle
@@ -1,0 +1,25 @@
+/*
+ * MIT License
+ *
+ * Copyright (c) 2026 Nima Karimipour
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+rootProject.name = 'java-25'

--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -33,7 +33,7 @@ def versions = [
         errorProne              : latestErrorProneVersion,
         errorProneApi           : project.hasProperty("epApiVersion") ? epApiVersion : oldestErrorProneApi,
         autoService             : "1.0-rc7",
-        javaparser              : "3.27.0",
+        javaparser              : "3.28.2",
         gson                    : "2.11.0",
         guava                   : "31.0.1-jre",
         cli                     : "1.5.0",


### PR DESCRIPTION
## Problem

`-ll` accepts only `11`, `17` and `21`. A project compiled with a newer release fails to parse before any inference runs — on JDK 22+ an unnamed variable aborts the whole run:

```
ParseException: javaparser was not able to parse file at: .../ClickHouseBatchInserter.java
Parse problem:(line 51,col 28) '_' is a reserved keyword.
```

That is #240. Unnamed variables are stable since JEP 456 (JDK 22), so the failure is reachable from any current LTS, and there is no `-ll` value that avoids it: the bundled JavaParser 3.27.0 tops out at `JAVA_21`.

Each new release otherwise needs another `case` in `Config`, as #276 did for 21.

## Changes

- `Config.getLanguageLevel` resolves the value against `ParserConfiguration.LanguageLevel` instead of a fixed switch, so every level the parser knows is accepted and future releases need no code change. Unknown values still fail with the same `IllegalArgumentException`.
- JavaParser 3.27.0 → 3.28.2, which adds `JAVA_22` … `JAVA_26`.
- `-ll` docs in `README.md` and `OPTIONS.md` state the range and why the value must match the target project.

## Verification

Built from this branch and run with `-ll 25` over a 21-module Gradle project on JDK 25 (records, switch patterns, unnamed variables): the parse failure is gone and inference completes.
