### PR TITLE
Run the analysis stack on current Error Prone and NullAway

### DIFF
--- a/annotator-core/build.gradle
+++ b/annotator-core/build.gradle
@@ -54,14 +54,12 @@ spotless {
     }
 }
 
-// Should be the latest supporting version of NullAway.
-def NULLAWAY_TEST = "0.12.4"
-
 tasks.test.dependsOn(':annotator-scanner:publishToMavenLocal')
 
 // Set up environment variables for test configuration tu run with the latest development version.
 tasks.test.doFirst {
-    environment "NULLAWAY_TEST_VERSION", NULLAWAY_TEST
+    environment "NULLAWAY_TEST_VERSION", deps.versions.nullaway
+    environment "ERROR_PRONE_TEST_VERSION", deps.versions.errorProne
     environment "ANNOTATOR_VERSION", project.version
 }
 

--- a/annotator-core/src/main/java/edu/ucr/cs/riple/core/checkers/nullaway/NullAway.java
+++ b/annotator-core/src/main/java/edu/ucr/cs/riple/core/checkers/nullaway/NullAway.java
@@ -185,10 +185,11 @@ public class NullAway extends CheckerBaseClass<NullAwayError> {
     Set<String> fields =
         Arrays.stream(fieldsData)
             // NullAway serializes line number right after a field name starting with an open
-            // parentheses. (e.g. foo (line z)). This approach of extracting field names is
-            // extremely dependent on the format of NullAway error messages. Should be watched
-            // carefully and updated if the format is changed by NullAway (maybe regex?).
-            .map(s -> s.substring(0, s.indexOf("(")).trim())
+            // parentheses. (e.g. foo (line z)). Since 0.13.8 the name itself is quoted
+            // (e.g. 'foo' (line z)). This approach of extracting field names is extremely
+            // dependent on the format of NullAway error messages. Should be watched carefully
+            // and updated if the format is changed by NullAway (maybe regex?).
+            .map(s -> unquote(s.substring(0, s.indexOf("(")).trim()))
             .collect(Collectors.toSet());
     if (fields.size() == 0) {
       throw new RuntimeException(
@@ -198,6 +199,19 @@ public class NullAway extends CheckerBaseClass<NullAwayError> {
               + errorMessage);
     }
     return fields;
+  }
+
+  /**
+   * Removes the enclosing single quotes NullAway puts around syntax element references in its error
+   * messages, leaving an unquoted name untouched.
+   *
+   * @param name Name as it appears in the error message.
+   * @return Name without the enclosing quotes.
+   */
+  private static String unquote(String name) {
+    return name.length() > 1 && name.charAt(0) == '\'' && name.charAt(name.length() - 1) == '\''
+        ? name.substring(1, name.length() - 1)
+        : name;
   }
 
   /**

--- a/annotator-core/src/test/resources/templates/java-17/build.gradle
+++ b/annotator-core/src/test/resources/templates/java-17/build.gradle
@@ -57,7 +57,7 @@ subprojects {
         compileOnly 'org.jetbrains:annotations:24.0.0'
         compileOnly "org.jspecify:jspecify:0.3.0"
         compileOnly "com.google.code.findbugs:jsr305:3.0.2"
-        errorprone "com.google.errorprone:error_prone_core:2.31.0"
+        errorprone "com.google.errorprone:error_prone_core:" + System.getenv('ERROR_PRONE_TEST_VERSION')
     }
 
     tasks.withType(JavaCompile) {

--- a/annotator-core/src/test/resources/templates/java-21/build.gradle
+++ b/annotator-core/src/test/resources/templates/java-21/build.gradle
@@ -59,7 +59,7 @@ subprojects {
         compileOnly 'org.jetbrains:annotations:24.0.0'
         compileOnly "org.jspecify:jspecify:0.3.0"
         compileOnly "com.google.code.findbugs:jsr305:3.0.2"
-        errorprone "com.google.errorprone:error_prone_core:2.31.0"
+        errorprone "com.google.errorprone:error_prone_core:" + System.getenv('ERROR_PRONE_TEST_VERSION')
     }
 
     tasks.withType(JavaCompile) {

--- a/annotator-core/src/test/resources/templates/lombok/build.gradle
+++ b/annotator-core/src/test/resources/templates/lombok/build.gradle
@@ -59,7 +59,7 @@ subprojects {
         compileOnly 'com.uber.nullaway:nullaway-annotations:0.10.10'
         compileOnly "org.jspecify:jspecify:0.3.0"
         compileOnly "com.google.code.findbugs:jsr305:3.0.2"
-        errorprone "com.google.errorprone:error_prone_core:2.31.0"
+        errorprone "com.google.errorprone:error_prone_core:" + System.getenv('ERROR_PRONE_TEST_VERSION')
     }
 
     tasks.withType(JavaCompile) {

--- a/annotator-core/src/test/resources/templates/nullable-multi-modular/build.gradle
+++ b/annotator-core/src/test/resources/templates/nullable-multi-modular/build.gradle
@@ -57,7 +57,7 @@ subprojects {
         compileOnly 'org.jetbrains:annotations:24.0.0'
         compileOnly "org.jspecify:jspecify:0.3.0"
         compileOnly "com.google.code.findbugs:jsr305:3.0.2"
-        errorprone "com.google.errorprone:error_prone_core:2.31.0"
+        errorprone "com.google.errorprone:error_prone_core:" + System.getenv('ERROR_PRONE_TEST_VERSION')
     }
 
     tasks.withType(JavaCompile) {

--- a/annotator-scanner/src/test/java/edu/ucr/cs/riple/scanner/ClassRecordTest.java
+++ b/annotator-scanner/src/test/java/edu/ucr/cs/riple/scanner/ClassRecordTest.java
@@ -27,6 +27,7 @@ package edu.ucr.cs.riple.scanner;
 import com.google.common.base.Preconditions;
 import edu.ucr.cs.riple.scanner.tools.ClassRecordDisplay;
 import edu.ucr.cs.riple.scanner.tools.DisplayFactory;
+import java.nio.file.Path;
 import org.junit.Test;
 
 public class ClassRecordTest extends AnnotatorScannerBaseTest<ClassRecordDisplay> {
@@ -36,9 +37,11 @@ public class ClassRecordTest extends AnnotatorScannerBaseTest<ClassRecordDisplay
         Preconditions.checkArgument(values.length == 2, "Expected to find 2 values on each line");
         // Outputs are written in Temp Directory and is not known at compile time, therefore,
         // relative paths are getting compared.
-        ClassRecordDisplay display = new ClassRecordDisplay(values[0], values[1]);
-        display.path = display.path.substring(display.path.indexOf("edu/ucr/"));
-        return new ClassRecordDisplay(values[0], values[1].substring(1));
+        String normalizedPath = Path.of(values[1]).normalize().toString().replace('\\', '/');
+        int relativePathStart = normalizedPath.indexOf("edu/ucr/");
+        Preconditions.checkArgument(
+            relativePathStart >= 0, "Expected source path under edu/ucr/: %s", normalizedPath);
+        return new ClassRecordDisplay(values[0], normalizedPath.substring(relativePathStart));
       };
   private static final String HEADER = "class\tpath";
   private static final String FILE_NAME = "class_records.tsv";

--- a/annotator-scanner/src/test/java/edu/ucr/cs/riple/scanner/tools/SerializationTestHelper.java
+++ b/annotator-scanner/src/test/java/edu/ucr/cs/riple/scanner/tools/SerializationTestHelper.java
@@ -25,6 +25,7 @@
 package edu.ucr.cs.riple.scanner.tools;
 
 import static org.junit.Assert.assertThrows;
+import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
 import com.google.common.base.Preconditions;
@@ -39,7 +40,6 @@ import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.stream.Collectors;
-import org.openjdk.tools.javac.util.Assert;
 
 public class SerializationTestHelper<T extends Display> {
 
@@ -168,7 +168,7 @@ public class SerializationTestHelper<T extends Display> {
     String fullExpectedMessage = "Caused by: " + exception.getName() + ": " + expectedErrorMessage;
     prepareTest();
     AssertionError ex = assertThrows(AssertionError.class, () -> compilationTestHelper.doTest());
-    Assert.check(ex.getMessage().contains(fullExpectedMessage));
+    assertTrue(ex.getMessage().contains(fullExpectedMessage));
   }
 
   /** Runs the test. */

--- a/build.gradle
+++ b/build.gradle
@@ -110,7 +110,7 @@ subprojects { proj ->
 
     spotless {
         java {
-            googleJavaFormat('1.30.0')
+            googleJavaFormat('1.28.0')
         }
     }
 }

--- a/build.gradle
+++ b/build.gradle
@@ -71,6 +71,11 @@ subprojects { proj ->
     }
 
     proj.tasks.withType(JavaCompile) {
+        options.compilerArgs += [
+                "--add-exports=jdk.compiler/com.sun.tools.javac.code=ALL-UNNAMED",
+                "--add-exports=jdk.compiler/com.sun.tools.javac.tree=ALL-UNNAMED",
+                "--add-exports=jdk.compiler/com.sun.tools.javac.util=ALL-UNNAMED"
+        ]
         if (!name.toLowerCase().contains("test")) {
             options.errorprone {
                 check("StringSplitter", CheckSeverity.OFF)
@@ -82,6 +87,14 @@ subprojects { proj ->
             }
         }
         options.fork = true
+    }
+
+    proj.tasks.withType(Javadoc) {
+        options.addMultilineStringsOption("-add-exports").setValue([
+                "jdk.compiler/com.sun.tools.javac.code=ALL-UNNAMED",
+                "jdk.compiler/com.sun.tools.javac.tree=ALL-UNNAMED",
+                "jdk.compiler/com.sun.tools.javac.util=ALL-UNNAMED"
+        ])
     }
 
     repositories {
@@ -97,7 +110,7 @@ subprojects { proj ->
 
     spotless {
         java {
-            googleJavaFormat('1.24.0')
+            googleJavaFormat('1.30.0')
         }
     }
 }

--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -24,8 +24,9 @@
 
 // The oldest version of Error Prone that we support running on
 def oldestErrorProneApi = "2.4.0"
-// Latest released Error Prone version that we've tested with
-def latestErrorProneVersion = "2.14.0"
+// Latest Error Prone that still runs on the JDK 17 floor, also used by the test target projects.
+// 2.45.0 and later ship class file 65 and need JDK 21 to load.
+def latestErrorProneVersion = "2.42.0"
 
 
 def versions = [
@@ -39,7 +40,8 @@ def versions = [
         commonsio               : "2.11.0",
         progressbar             : "0.9.2",
         junitjupiter            : "5.7.2",
-        nullaway                : "0.10.19",
+        // Latest NullAway that still writes the serialization version NullAway.VERSION reads
+        nullaway                : "0.13.8",
         mockito                 : "5.2.0",
         junit                   : "4.13.2"
 ]

--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -23,7 +23,7 @@
  */
 
 // The oldest version of Error Prone that we support running on
-def oldestErrorProneApi = "2.4.0"
+def oldestErrorProneApi = "2.36.0"
 // Latest Error Prone that still runs on the JDK 17 floor, also used by the test target projects.
 // 2.45.0 and later ship class file 65 and need JDK 21 to load.
 def latestErrorProneVersion = "2.42.0"


### PR DESCRIPTION
Follow-up to #280, and the toolchain half of #279.

## Why

The build cannot run on a current JDK, and the failure is in Error Prone, not in this project's code.

`error_prone_core:2.14.0` — the version the repo compiles itself with — dies on JDK 25 the moment a check touches the AST:

```
error: An unhandled exception was thrown by the Error Prone static analysis plugin.
     error-prone version: 2.14.0
     java.lang.NoSuchFieldError: Class com.sun.tools.javac.code.TypeTag does not have member field 'com.sun.tools.javac.code.TypeTag UNKNOWN'
  	at com.google.errorprone.util.ASTHelpers.<clinit>(ASTHelpers.java:1238)
```

The target-project templates hit the same wall one level down: they pin `2.31.0`, so `:Target:compileJava` inside the integration tests fails with the identical stack. That is what caps CI at JDK 22 today and blocks the JDK 25 job asked for in #279.

## What changes

- `latestErrorProneVersion` 2.14.0 -> 2.42.0, and the four target-project templates take that same version from `ERROR_PRONE_TEST_VERSION` instead of pinning `2.31.0` in four places. `annotator-core` exports it from `deps.versions.errorProne` next to `NULLAWAY_TEST_VERSION` and `ANNOTATOR_VERSION`.

  2.42.0 rather than the newest release, because 2.45.0 raised the runtime floor: from that version `error_prone_core` ships class file 65, so it cannot load on the JDK 17 that #280 established as this repo's floor —

  ```
  java.lang.UnsupportedClassVersionError: com/google/errorprone/ErrorProneJavacPlugin has been compiled by a more recent version of the Java Runtime (class file version 65.0), this version of the Java Runtime only recognizes class file versions up to 61.0
  ```

  2.42.0 is the last release that still runs on JDK 17 and already handles JDK 25 — checked on a JDK 25 build of a target project using an unnamed variable, which is the syntax #279 needs.

  If you would rather be on the current Error Prone, the change that gets you there without touching what the artifacts require of users is to split the build JDK from the release target: run the jobs on 21 and compile with `--release 17`, leaving `targetCompatibility` where it is. Say the word and I will do that in this PR instead.

  `oldestErrorProneApi` is untouched at 2.4.0, so `annotator-scanner` and the custom checks still build against the old API and the supported-runtime floor is unchanged.

- NullAway 0.10.19 / 0.12.4 -> 0.13.8. The repo carried two NullAway versions in two files (`versions.nullaway` for `library-model-loader`, `NULLAWAY_TEST` for the integration tests); `NULLAWAY_TEST` now reads `deps.versions.nullaway`, so there is one version.

- `extractUninitializedFieldNames` accepts NullAway's quoted syntax element references. Since 0.13.8 (#1620) the initializer message reads `'f' (line 3)` where it used to read `f (line 3)`, and the quotes ended up inside the field name: the registry lookup missed, `OnField{variables=['f']}` reports appeared next to the real ones, and ten `CoreTest`/`DeepTest` cases failed. The method's own comment asked for exactly this ("should be watched carefully and updated if the format is changed by NullAway"); it now tolerates both spellings, so the parse does not pin a NullAway version.

NullAway 0.14.0 is deliberately not taken: it writes serialization version 4 while `NullAway.VERSION` here is 3, so every integration test stops at `verifyCheckerCompatibility` with *"This Annotator version only supports NullAway serialization version 3, but found: 4"*. Reading version 4 is separate work; the version note in `dependencies.gradle` records the ceiling.

## Verified

`:annotator-core:spotlessCheck` and `:annotator-core:test` green on Temurin 17 and 21, and `:checks:ban-mutable-static:compileJava` plus `:annotator-core:compileJava` green on 17, 21 and 25.

With this in, #279 rebases on top and moves its integration test and CI job to JDK 25.
