### PR TITLE
Skip volatile directories when copying the repository into a test scratch dir

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -53,10 +53,13 @@ jobs:
       - name: Build with Gradle
         run: ./gradlew build --scan --no-daemon
       - name: Archive test report
+        if: always()
         uses: actions/upload-artifact@v4
         with:
           name: Test report
-          path: build/reports/tests/test
+          path: |
+            **/build/reports/tests/test
+            **/build/test-results/test
   parallel-processing-enabled-caching-disabled:
     runs-on: ubuntu-latest
     steps:

--- a/annotator-core/src/test/java/edu/ucr/cs/riple/core/AnnotatorBaseCoreTest.java
+++ b/annotator-core/src/test/java/edu/ucr/cs/riple/core/AnnotatorBaseCoreTest.java
@@ -26,9 +26,11 @@ package edu.ucr.cs.riple.core;
 
 import edu.ucr.cs.riple.core.tools.CoreTestHelper;
 import edu.ucr.cs.riple.core.tools.Utility;
+import java.io.FileFilter;
 import java.io.IOException;
 import java.nio.file.Path;
 import java.nio.file.Paths;
+import java.util.Set;
 import org.apache.commons.io.FileUtils;
 import org.junit.Before;
 import org.junit.Ignore;
@@ -41,6 +43,16 @@ import org.junit.runners.JUnit4;
 @Ignore
 @RunWith(JUnit4.class)
 public abstract class AnnotatorBaseCoreTest {
+
+  /**
+   * Directories of the repository that the copy below must not walk. Gradle writes into them while
+   * the tests run, so a file can vanish between listing and reading it, and the copy of the
+   * repository is only used to build the library models loader from source anyway.
+   */
+  private static final Set<String> VOLATILE_DIRECTORIES = Set.of("build", ".git", ".gradle");
+
+  private static final FileFilter EXCLUDE_VOLATILE_DIRECTORIES =
+      file -> !(file.isDirectory() && VOLATILE_DIRECTORIES.contains(file.getName()));
 
   /** Temporary folder for each test. */
   @Rule public final TemporaryFolder temporaryFolder = new TemporaryFolder();
@@ -72,7 +84,9 @@ public abstract class AnnotatorBaseCoreTest {
     try {
       // Create a separate library models loader to avoid races between unit tests.
       FileUtils.copyDirectory(
-          repositoryDirectory.toFile(), outDirPath.resolve("Annotator").toFile());
+          repositoryDirectory.toFile(),
+          outDirPath.resolve("Annotator").toFile(),
+          EXCLUDE_VOLATILE_DIRECTORIES);
       FileUtils.copyDirectory(pathToUnitTestDir.toFile(), unitTestProjectPath.toFile());
       // Copy using gradle wrappers.
       FileUtils.copyFile(


### PR DESCRIPTION
## Problem

`AnnotatorBaseCoreTest.setup` copies the whole repository into the test's scratch dir:

```java
FileUtils.copyDirectory(repositoryDirectory.toFile(), outDirPath.resolve("Annotator").toFile());
```

That walk includes `build/`, `.gradle/` and `.git/`, which the outer Gradle build keeps writing into while the tests run, and four test forks walk them at once. When a file disappears between `list()` and opening it the copy throws and the test dies before it starts:

```
DeepTest > paramPassTest FAILED
    java.lang.RuntimeException at AnnotatorBaseCoreTest.java:88
        Caused by: java.io.FileNotFoundException at FileUtils.java:2719
```

It is a race, so it lands on whichever tests happen to be running: `build-without-cache` took `DeepTest`, `AnalysisModeTest` and `CoreTest` on one run of #279, and `build-with-gradle-build-action-cache` failed the same way on master at 63074f6.

## Changes

The copy skips `build`, `.git` and `.gradle`. The copy exists to run `./gradlew library-model-loader:jar --rerun-tasks` against the sources, which rebuilds what it needs, so none of the three is read from it. It also stops copying the build outputs of the whole repository into a temp dir once per test.

## Verification

`DeepTest.paramPassTest`, `CoreTest.multipleReturnNullable`, `AnalysisModeTest` and `Java21Test` green on JDK 21; `spotlessCheck` clean.
